### PR TITLE
Correct metrics get to statements count rather than statements and pscs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -139,7 +139,7 @@ public class PscStatementService {
               try {
                 statementList.setActiveCount(metricsApi.getCounts().getPersonsWithSignificantControl().getActiveStatementsCount());
                 statementList.setCeasedCount(metricsApi.getCounts().getPersonsWithSignificantControl().getWithdrawnStatementsCount());
-                statementList.setTotalResults(metricsApi.getCounts().getPersonsWithSignificantControl().getTotalCount());
+                statementList.setTotalResults(metricsApi.getCounts().getPersonsWithSignificantControl().getStatementsCount());
               } catch (NullPointerException exp) {
                 logger.error(String.format("No PSC data in metrics for company number %s", companyNumber));
               }

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
@@ -108,7 +108,7 @@ public class TestHelper {
         PscApi pscs = new PscApi();
         pscs.setActiveStatementsCount(1);
         pscs.setWithdrawnStatementsCount(1);
-        pscs.setTotalCount(2);
+        pscs.setStatementsCount(2);
         counts.setPersonsWithSignificantControl(pscs);
         metrics.setCounts(counts);
         return metrics;


### PR DESCRIPTION
This PR updates the metrics element of the statements list call to return just the total statements count rather than the statements + pscs