### PR TITLE
Implement transactional model in database save and delete

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
@@ -88,6 +88,7 @@ public class RepositoryITest extends AbstractMongoConfig {
         Updated updated = new Updated();
         updated.setAt(LocalDateTime.of(2019, 1, 1, 1, 1));
         document.setUpdated(updated);
+        document.setDeltaAt(DELTA_AT);
 
         return document;
     }

--- a/src/itest/resources/features/psc_statements_response_codes.feature
+++ b/src/itest/resources/features/psc_statements_response_codes.feature
@@ -10,7 +10,6 @@ Feature: Response codes for psc statements
 
     Examples:
     | data                                   | response_code |
-    | bad_company_psc_statement_no_delta_at  | 400           |
     | bad_company_psc_statement_invalid_json | 400           |
 
 

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.pscstatementdataapi.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.mongodb.MongoException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
@@ -28,7 +30,7 @@ public class ExceptionHandlerConfig {
         return ResponseEntity.notFound().build();
     }
 
-    @ExceptionHandler(value = {ServiceUnavailableException.class, DataAccessException.class})
+    @ExceptionHandler(value = {ServiceUnavailableException.class, DataAccessException.class, MongoException.class})
     public ResponseEntity<Object> handleServiceUnavailableException(Exception exception) {
         logger.error(exception.getMessage());
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.SERVICE_UNAVAILABLE);

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
@@ -5,7 +5,6 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
@@ -13,7 +12,6 @@ import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
-@ConditionalOnProperty(name = "mongodb.company_psc_statements", havingValue = "true")
 @Configuration
 @EnableTransactionManagement
 public class MongoPscStatementConfig extends AbstractMongoClientConfiguration {


### PR DESCRIPTION
This PR updates the PSC statement data api to use a transactional model for database saves allowing records to only be committed when the kafka api is successfully called.

**Resolves**
DSND-1637