### PR TITLE
Make transactional configuration dependent on config, fixes synergy1 and other envs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
@@ -5,6 +5,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
@@ -12,6 +13,7 @@ import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+@ConditionalOnProperty(name = "mongodb.transactional", havingValue = "true")
 @Configuration
 @EnableTransactionManagement
 public class MongoPscStatementConfig extends AbstractMongoClientConfiguration {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,4 @@ mongodb:
   pscStatements:
     collection:
       name: company_psc_statements
+  transactional: ${TRANSACTIONAL_ON:false}


### PR DESCRIPTION
This PR ensures transaction manager config is only set up at app startup when a config value is set to true. This will allow transactions to be used in cidev, staging and live while allowing them to be off in synergy1/locally until docker has a replica set mongo image. 