### PR TITLE
Add customConversions to override abstract method

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 @Configuration
 public class ApplicationConfig {
 
-
     @Bean
     public MongoCustomConversions mongoCustomConversions(){
         ObjectMapper objectMapper = mongoDbObjectMapper();

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
@@ -4,6 +4,8 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @ConditionalOnProperty(name = "mongodb.transactional", havingValue = "true")
@@ -24,6 +27,9 @@ public class MongoPscStatementConfig extends AbstractMongoClientConfiguration {
     @Value("${spring.data.mongodb.uri}")
     private String databaseUri;
 
+    @Autowired
+    MongoCustomConversions mongoCustomConversions;
+
     @Bean
     MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
         return new MongoTransactionManager(dbFactory);
@@ -36,6 +42,11 @@ public class MongoPscStatementConfig extends AbstractMongoClientConfiguration {
 
     protected String getDatabaseUri() {
         return this.databaseUri;
+    }
+
+    @Override
+    public MongoCustomConversions customConversions() {
+        return this.mongoCustomConversions;
     }
 
     @Override


### PR DESCRIPTION
Override the parent customConversions method with our own from application config to prevent our object mapper alterations being lost when reading from/writing to mongo.