### PR TITLE
Rework base path urls to use internal gateway

### DIFF
--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/CompanyExemptionsApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/CompanyExemptionsApiService.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.pscstatementdataapi.api;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -22,12 +23,14 @@ public class CompanyExemptionsApiService {
     @Autowired
     InternalApiClient internalApiClient;
 
+    @Value("${chs.api.exemptions.url}")
+    private String basePath;
+
     @Autowired
     Logger logger;
 
     public Optional<CompanyExemptions> getCompanyExeptions (final String companyNumber) {
         logger.trace(String.format("Started : getCompanyExemptions for Company Number %s ", companyNumber));
-        String basePath = System.getenv("API_URL");
         internalApiClient.setBasePath(basePath);
         logger.trace(String.format("Created client %s", internalApiClient.getBasePath()));
         PrivateCompanyExemptionsGetAll companyExemptions = 

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/CompanyMetricsApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/CompanyMetricsApiService.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.pscstatementdataapi.api;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.api.InternalApiClient;
@@ -22,6 +23,9 @@ public class CompanyMetricsApiService {
     @Autowired
     InternalApiClient internalApiClient;
 
+    @Value("${chs.api.metrics.url}")
+    private String basePath;
+
     /**
      * Invoke Company Metrics API.
      */
@@ -38,7 +42,6 @@ public class CompanyMetricsApiService {
         logger.trace(String.format("Started : getCompanyMetrics for Company Number %s ",
                 companyNumber
         ));
-        String basePath = System.getenv("API_URL");
         internalApiClient.setBasePath(basePath);
         logger.trace(String.format("Created client %s", internalApiClient.getBasePath()));
         PrivateCompanyMetricsGet companyMetrics =

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiService.java
@@ -19,11 +19,11 @@ public class PscStatementApiService {
 
     @Autowired
     InternalApiClient internalApiClient;
-    @Value("${chs.kafka.api.endpoint}")
+    @Value("${chs.api.kafka.url}")
     private String chsKafkaApiUrl;
-    @Value("${psc-statements.api.resource.changed.uri}")
+    @Value("${chs.api.kafka.uri}")
     private String resourceChangedUri;
-    @Value("${psc-statements.api.resource.kind}")
+    @Value("${chs.api.kafka.kind}")
     private String resourceKind;
     private static final String PSC_STATEMENTS_URI = "/company/%s/persons-with-significant-control-statements/%s";
     private static final String CHANGED_EVENT_TYPE = "changed";

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
-import uk.gov.companieshouse.api.exemptions.Exemptions;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.RegisterApi;
 import uk.gov.companieshouse.api.metrics.RegistersApi;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,18 +6,15 @@ management:
         health: /healthcheck
 
 chs:
-  kafka:
-    api:
-      endpoint: ${CHS_KAFKA_API_URL:localhost}
-      key: ${CHS_API_KEY:chsApiKey}
-      enabled: ${DSQ_STREAM_HOOK_ENABLED:true}
-
-psc-statements:
   api:
-    resource:
-      changed:
-        uri: ${PSC_STATEMENTS_API_RESOURCE_CHANGED_URI:/private/resource-changed}
+    kafka:
+      url: ${CHS_KAFKA_API_URL:localhost}
+      uri: ${PSC_STATEMENTS_API_RESOURCE_CHANGED_URI:/private/resource-changed}
       kind: ${PSC_STATEMENTS_API_RESOURCE_KIND:persons-with-significant-control-statement}
+    exemptions:
+      url: ${CHS_EXEMPTIONS_DATA_API_URL:localhost}
+    metrics:
+      url: ${CHS_METRICS_DATA_API_URL:localhost}
 
 logger:
   namespace: psc-statement-data-api


### PR DESCRIPTION
This PR updates the application config to pass in and use gateway urls for the api clients retrieving exemptions and metrics data.

**Resolves**
DSND-1710