### PR TITLE
Changing the psc-statements-data-api routes.yaml weight to be 904, le…

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,6 +1,6 @@
 app_name: psc-statement-data-api
 group: api
-weight: 991
+weight: 904
 routes:
    1: ^/psc-statement-data-api/healthcheck
    2: ^/company/(.){0,10}/persons-with-significant-control-statements


### PR DESCRIPTION
…ss than that of psc-data-api, to avoid the psc-data-api capturing statements traffic. DSND-2291