### PR TITLE
DSND-3114: Add DeltaAt to DELETE endpoint header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 
 .PHONY: build
 build:
-	mvn org.codehaus.mojo:versions-maven-plugin:2.17.1:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
 	mvn package -DskipTests=true
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
@@ -49,7 +49,7 @@ ifndef version
 	$(error No version given. Aborting)
 endif
 	$(info Packaging version: $(version))
-	mvn org.codehaus.mojo:versions-maven-plugin:2.17.1:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
 	mvn package -DskipTests=true
 	$(eval tmpdir:=$(shell mktemp -d build-XXXXXXXXXX))
 	cp ./start.sh $(tmpdir)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean:
 
 .PHONY: build
 build:
-	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn org.codehaus.mojo:versions-maven-plugin:2.17.1:set -DnewVersion=$(version) -DgenerateBackupPoms=false
 	mvn package -DskipTests=true
 	cp ./target/$(artifact_name)-$(version).jar ./$(artifact_name).jar
 
@@ -49,7 +49,7 @@ ifndef version
 	$(error No version given. Aborting)
 endif
 	$(info Packaging version: $(version))
-	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
+	mvn org.codehaus.mojo:versions-maven-plugin:2.17.1:set -DnewVersion=$(version) -DgenerateBackupPoms=false
 	mvn package -DskipTests=true
 	$(eval tmpdir:=$(shell mktemp -d build-XXXXXXXXXX))
 	cp ./start.sh $(tmpdir)

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <io-cucumber.version>7.15.0</io-cucumber.version>
-        <test-containers.version>1.20.3</test-containers.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <assertj-core.version>3.25.3</assertj-core.version>
         <skip.integration.tests>false</skip.integration.tests>
@@ -35,17 +34,12 @@
         <docker-java-api.version>3.3.6</docker-java-api.version>
 
         <!-- Internal -->
-        <ch-kafka.version>1.4.8</ch-kafka.version>
-        <kafka-models.version>1.0.33</kafka-models.version>
-        <spring.boot.version>3.4.0</spring.boot.version>
-        <spring.framework.version>5.3.11</spring.framework.version>
         <structured-logging.version>3.0.9</structured-logging.version>
         <private-api-sdk-java.version>4.0.179</private-api-sdk-java.version>
-        <data-sync-api-sdk-java.version>unversioned</data-sync-api-sdk-java.version>
+        <data-sync-api-sdk-java.version>1.0.9</data-sync-api-sdk-java.version>
         <api-security-java.version>2.0.5</api-security-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
-        <wiremock.standalone.version>2.35.0</wiremock.standalone.version>
 
         <!--sonar configuration-->
         <sonar-maven-plugin.version>3.11.0.3922</sonar-maven-plugin.version>
@@ -68,13 +62,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${test-containers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -218,12 +218,6 @@
       <!-- Overrides -->
       <!-- CVE-2024-38809 -->
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-web</artifactId>
-        <version>6.1.12</version>
-      </dependency>
-      <!-- CVE-2024-38809 -->
-      <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
         <version>6.3.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <spring.framework.version>5.3.11</spring.framework.version>
         <structured-logging.version>3.0.9</structured-logging.version>
         <private-api-sdk-java.version>4.0.179</private-api-sdk-java.version>
-        <data-sync-api-sdk-java.version>1.0.8</data-sync-api-sdk-java.version>
+        <data-sync-api-sdk-java.version>unversioned</data-sync-api-sdk-java.version>
         <api-security-java.version>2.0.5</api-security-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.10</version>
     </parent>
     <artifactId>psc-statement-data-api</artifactId>
     <version>unversioned</version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
         <java.version>21</java.version>
         <start-class>uk.gov.companieshouse.pscstatementdataapi.PSCStatementDataApiApplication</start-class>
 
-        <maven-build-helper-plugin.version>3.5.0</maven-build-helper-plugin.version>
-        <spring-boot-dependencies.version>3.3.2</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.3.2</spring-boot-maven-plugin.version>
+        <maven-build-helper-plugin.version>3.6.0</maven-build-helper-plugin.version>
+        <spring-boot-dependencies.version>3.3.5</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.3.5</spring-boot-maven-plugin.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -26,7 +26,7 @@
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
         <io-cucumber.version>7.15.0</io-cucumber.version>
-        <test-containers.version>1.19.7</test-containers.version>
+        <test-containers.version>1.20.3</test-containers.version>
         <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <assertj-core.version>3.25.3</assertj-core.version>
         <skip.integration.tests>false</skip.integration.tests>
@@ -37,7 +37,7 @@
         <!-- Internal -->
         <ch-kafka.version>1.4.8</ch-kafka.version>
         <kafka-models.version>1.0.33</kafka-models.version>
-        <spring.boot.version>2.7.13</spring.boot.version>
+        <spring.boot.version>3.4.0</spring.boot.version>
         <spring.framework.version>5.3.11</spring.framework.version>
         <structured-logging.version>3.0.9</structured-logging.version>
         <private-api-sdk-java.version>4.0.179</private-api-sdk-java.version>
@@ -91,6 +91,14 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <!--		Transitive deps start here-->
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!--		Transitive deps end here-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
+            <exclusions>
+                <!--excluded to remove vulnerability-->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/CucumberFeaturesRunnerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/CucumberFeaturesRunnerITest.java
@@ -4,7 +4,6 @@ import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.runner.RunWith;
-
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.companieshouse.pscstatementdataapi.config.AbstractIntegrationTest;
 

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
@@ -2,19 +2,17 @@ package uk.gov.companieshouse.pscstatementdataapi.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import uk.gov.companieshouse.pscstatementdataapi.config.AbstractMongoConfig;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import uk.gov.companieshouse.api.psc.Statement;
-import uk.gov.companieshouse.api.model.Updated;
-
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.api.model.Updated;
+import uk.gov.companieshouse.api.psc.Statement;
+import uk.gov.companieshouse.pscstatementdataapi.config.AbstractMongoConfig;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 @Testcontainers

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
@@ -11,11 +11,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.gov.companieshouse.api.psc.Statement;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
 import uk.gov.companieshouse.api.model.Updated;
 
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 @Testcontainers
 @DataMongoTest

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
@@ -24,11 +24,11 @@ import uk.gov.companieshouse.api.exemptions.ExemptionItem;
 import uk.gov.companieshouse.api.exemptions.Exemptions;
 import uk.gov.companieshouse.api.exemptions.PscExemptAsSharesAdmittedOnMarketItem;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
 import uk.gov.companieshouse.api.psc.Statement;
 import uk.gov.companieshouse.api.psc.StatementList;
 import uk.gov.companieshouse.pscstatementdataapi.api.PscStatementApiService;
 import uk.gov.companieshouse.pscstatementdataapi.config.CucumberContext;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 import uk.gov.companieshouse.pscstatementdataapi.repository.PscStatementRepository;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
 import uk.gov.companieshouse.pscstatementdataapi.util.FileReaderUtil;
@@ -39,7 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequest;
+import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -380,7 +380,7 @@ public class PscStatementsSteps {
 
     @When("psc statement id does not exist for {string}")
     public void statement_does_not_exist(String statementId) {
-        CucumberContext.CONTEXT.set("pscStatementDocument", null);
+        CucumberContext.CONTEXT.set("pscStatementDocument", new PscStatementDocument());
         assertThat(pscStatementRepository.existsById(statementId)).isFalse();
     }
 
@@ -397,10 +397,10 @@ public class PscStatementsSteps {
 
     @Then("the CHS Kafka API delete is invoked for company number {string} with statement id {string} and the correct statement data")
     public void chs_kafka_api_invoked_delete(String companyNumber, String statementId) throws IOException {
-        Optional<PscStatementDocument> document = Optional.ofNullable(CucumberContext.CONTEXT.get("pscStatementDocument"));
+        PscStatementDocument document = CucumberContext.CONTEXT.get("pscStatementDocument");
         ResourceChangedRequest resourceChangedRequest = new ResourceChangedRequest(
                 CucumberContext.CONTEXT.get("contextId"), companyNumber, statementId, document, true);
-        verify(pscStatementApiService).invokeChsKafkaApi(resourceChangedRequest);
+        verify(pscStatementApiService).invokeChsKafkaApiDelete(resourceChangedRequest);
     }
 
     @When("a statement exists with id {string}")
@@ -428,7 +428,7 @@ public class PscStatementsSteps {
     @Then("nothing is persisted in the database")
     public void nothing_persisted_to_database() {
         List<PscStatementDocument> pscDocs = pscStatementRepository.findAll();
-       assertThat(pscDocs).hasSize(0);
+        assertThat(pscDocs).hasSize(0);
     }
 
     @After

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
@@ -172,7 +172,7 @@ public class PscStatementsSteps {
         headers.set("ERIC-Identity", "TEST-IDENTITY");
         headers.set("ERIC-Identity-Type", "key");
         headers.set("ERIC-Authorised-Key-Roles", "*");
-        HttpEntity<String> request = new HttpEntity<String>(null, headers);
+        HttpEntity<String> request = new HttpEntity<>(null, headers);
 
         ResponseEntity<MetricsApi> response = restTemplate.exchange(uri, HttpMethod.GET, request,
                 MetricsApi.class, companyNumber);

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
@@ -9,7 +9,6 @@ import io.cucumber.java.en.When;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -34,7 +33,6 @@ import uk.gov.companieshouse.pscstatementdataapi.repository.PscStatementReposito
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
 import uk.gov.companieshouse.pscstatementdataapi.util.FileReaderUtil;
 
-import java.io.File;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Collections;

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
@@ -13,6 +13,7 @@ import static uk.gov.companieshouse.pscstatementdataapi.config.AbstractMongoConf
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -387,6 +388,12 @@ public class PscStatementsSteps {
     public void chs_kafka_service_unavailable() throws IOException {
         doThrow(ServiceUnavailableException.class)
                 .when(pscStatementApiService).invokeChsKafkaApi(any());
+    }
+
+    @And("CHS kafka API service is unavailable for delete")
+    public void chsKafkaAPIServiceIsUnavailableForDelete() {
+        doThrow(ServiceUnavailableException.class)
+                .when(pscStatementApiService).invokeChsKafkaApiDelete(any());
     }
 
     @Then("the CHS Kafka API is not invoked")

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/steps/PscStatementsSteps.java
@@ -1,11 +1,27 @@
 package uk.gov.companieshouse.pscstatementdataapi.steps;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static uk.gov.companieshouse.api.exemptions.PscExemptAsSharesAdmittedOnMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_SHARES_ADMITTED_ON_MARKET;
+import static uk.gov.companieshouse.pscstatementdataapi.config.AbstractMongoConfig.mongoDBContainer;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -29,27 +45,10 @@ import uk.gov.companieshouse.api.psc.StatementList;
 import uk.gov.companieshouse.pscstatementdataapi.api.PscStatementApiService;
 import uk.gov.companieshouse.pscstatementdataapi.config.CucumberContext;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
+import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.repository.PscStatementRepository;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
 import uk.gov.companieshouse.pscstatementdataapi.util.FileReaderUtil;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
-import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static uk.gov.companieshouse.api.exemptions.PscExemptAsSharesAdmittedOnMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_SHARES_ADMITTED_ON_MARKET;
-import static uk.gov.companieshouse.pscstatementdataapi.config.AbstractMongoConfig.mongoDBContainer;
 
 public class PscStatementsSteps {
     private String contextId;

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/util/FileReaderUtil.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/util/FileReaderUtil.java
@@ -1,11 +1,10 @@
 package uk.gov.companieshouse.pscstatementdataapi.util;
 
-import org.springframework.util.FileCopyUtils;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import org.springframework.util.FileCopyUtils;
 
 public class FileReaderUtil {
 

--- a/src/itest/resources/features/psc_statements_delete.feature
+++ b/src/itest/resources/features/psc_statements_delete.feature
@@ -64,7 +64,7 @@ Feature: Delete statement information
       | company_number | id_to_delete                | delta_at             |
       | OC421554       | DHTUrJoAuKdXw7zvkreyAm_SoH0 | 20241023093435661593 |
 
-  Scenario Outline: Delete psc statement with no delta at header
+  Scenario Outline: Delete psc statement with no delta at value in header
 
     Given Psc statements data api service is running
     And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"

--- a/src/itest/resources/features/psc_statements_delete.feature
+++ b/src/itest/resources/features/psc_statements_delete.feature
@@ -42,9 +42,9 @@ Feature: Delete statement information
 
     Given Psc statements data api service is running
     And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"
-    And CHS kafka API service is unavailable
+    And CHS kafka API service is unavailable for delete
     When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
-    Then I should receive 200 status code
+    Then I should receive 503 status code
     And no statement exists with id "<id_to_delete>"
 
     Examples:

--- a/src/itest/resources/features/psc_statements_delete.feature
+++ b/src/itest/resources/features/psc_statements_delete.feature
@@ -44,8 +44,8 @@ Feature: Delete statement information
     And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"
     And CHS kafka API service is unavailable
     When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
-    Then I should receive 503 status code
-    And a statement exists with id "<id_to_delete>"
+    Then I should receive 200 status code
+    And no statement exists with id "<id_to_delete>"
 
     Examples:
       | company_number | id_to_delete                |

--- a/src/itest/resources/features/psc_statements_delete.feature
+++ b/src/itest/resources/features/psc_statements_delete.feature
@@ -1,36 +1,78 @@
 Feature: Delete statement information
 
-  Scenario: Delete psc statement successfully
+  Scenario Outline: Delete psc statement successfully
 
     Given Psc statements data api service is running
-    And a psc statement exists for company number "company_number" with statement id "id_to_delete"
-    When I send DELETE request for company number "company_number" with statement id "id_to_delete"
+    And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"
+    When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
     Then I should receive 200 status code
-    And the CHS Kafka API delete is invoked for company number "company_number" with statement id "id_to_delete" and the correct statement data
-    And no statement exists with id "id_to_delete"
+    And the CHS Kafka API delete is invoked for company number "<company_number>" with statement id "<id_to_delete>" and the correct statement data
+    And no statement exists with id "<id_to_delete>"
 
-  Scenario: Delete psc statement while database is down
+    Examples:
+      | company_number | id_to_delete                |
+      | OC421554       | DHTUrJoAuKdXw7zvkreyAm_SoH0 |
+
+  Scenario Outline: Delete psc statement while database is down
 
     Given Psc statements data api service is running
-    And a psc statement exists for company number "company_number" with statement id "id_to_delete"
+    And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"
     And the database is down
-    When I send DELETE request for company number "company_number" with statement id "id_to_delete"
+    When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
     Then I should receive 503 status code
     And the CHS Kafka API is not invoked
 
-  Scenario: Delete psc statement information not found
+    Examples:
+      | company_number | id_to_delete                |
+      | OC421554       | DHTUrJoAuKdXw7zvkreyAm_SoH0 |
+
+  Scenario Outline: Delete psc statement information not found
 
     Given Psc statements data api service is running
-    When I send DELETE request for company number "does_not_exist" with statement id "does_not_exist"
-    And psc statement id does not exist for "does_not_exist"
-    Then I should receive 404 status code
-    And the CHS Kafka API is not invoked
+    When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
+    And psc statement id does not exist for "<id_to_delete>"
+    Then I should receive 200 status code
+    And the CHS Kafka API delete is invoked for company number "<company_number>" with statement id "<id_to_delete>" and the correct statement data
 
-  Scenario: Delete psc statement when kafka-api is not available
+    Examples:
+      | company_number | id_to_delete   |
+      | does_not_exist | does_not_exist |
+
+  Scenario Outline: Delete psc statement when kafka-api is not available
 
     Given Psc statements data api service is running
-    And a psc statement exists for company number "company_number" with statement id "id_to_delete"
+    And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"
     And CHS kafka API service is unavailable
-    When I send DELETE request for company number "company_number" with statement id "id_to_delete"
+    When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
     Then I should receive 503 status code
-    And a statement exists with id "id_to_delete"
+    And a statement exists with id "<id_to_delete>"
+
+    Examples:
+      | company_number | id_to_delete                |
+      | OC421554       | DHTUrJoAuKdXw7zvkreyAm_SoH0 |
+
+  Scenario Outline: Delete psc statement with stale delta
+
+    Given Psc statements data api service is running
+    And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>" and delta_at "<delta_at>"
+    When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>"
+    Then I should receive 409 status code
+    And the CHS Kafka API is not invoked
+    And a statement exists with id "<id_to_delete>"
+
+    Examples:
+      | company_number | id_to_delete                | delta_at             |
+      | OC421554       | DHTUrJoAuKdXw7zvkreyAm_SoH0 | 20241023093435661593 |
+
+  Scenario Outline: Delete psc statement with no delta at header
+
+    Given Psc statements data api service is running
+    And a psc statement exists for company number "<company_number>" with statement id "<id_to_delete>"
+    When I send DELETE request for company number "<company_number>" with statement id "<id_to_delete>" without delta at
+    Then I should receive 400 status code
+    And the CHS Kafka API is not invoked
+    And a statement exists with id "<id_to_delete>"
+
+    Examples:
+      | company_number | id_to_delete                |
+      | OC421554       | DHTUrJoAuKdXw7zvkreyAm_SoH0 |

--- a/src/itest/resources/features/psc_statements_response_codes.feature
+++ b/src/itest/resources/features/psc_statements_response_codes.feature
@@ -19,15 +19,14 @@ Feature: Response codes for psc statements
     When I send a PUT request with no ERIC headers
     Then I should receive 401 status code
 
-  Scenario Outline: Put psc statement when kafka-api is not available (Should be 503 and nothing saved to db)
 
+  Scenario Outline: Put psc statement when kafka-api is not available (Should be 503 and nothing saved to db)
 
     Given Psc statements data api service is running
     And CHS kafka API service is unavailable
     When I send a PUT request with payload "<data>" file for company number "<companyNumber>" with statement id "<statementId>"
-    Then I should receive 200 status code
+    Then I should receive 503 status code
     And the CHS Kafka API is invoked for company number "<companyNumber>" with statement id "<statementId>"
-
 
     Examples:
       | companyNumber | statementId                 | data                  |

--- a/src/itest/resources/features/psc_statements_response_codes.feature
+++ b/src/itest/resources/features/psc_statements_response_codes.feature
@@ -20,7 +20,7 @@ Feature: Response codes for psc statements
     Then I should receive 401 status code
 
 
-  Scenario Outline: Put psc statement when kafka-api is not available (Should be 503 and nothing saved to db)
+  Scenario Outline: Put psc statement when kafka-api is not available (Should be 503 and resource saved to db)
 
     Given Psc statements data api service is running
     And CHS kafka API service is unavailable

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiService.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.pscstatementdataapi.api;
 
+import static uk.gov.companieshouse.pscstatementdataapi.PSCStatementDataApiApplication.NAMESPACE;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
@@ -8,6 +10,7 @@ import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.pscstatementdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
@@ -15,21 +18,22 @@ import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapp
 @Service
 public class PscStatementApiService {
 
+    private static final Logger logger = LoggerFactory.getLogger(NAMESPACE);
+
     private final ResourceChangedRequestMapper mapper;
     private final InternalApiClient internalApiClient;
-    private final Logger logger;
-
-    @Value("${chs.api.kafka.url}")
-    private String chsKafkaApiUrl;
-    @Value("${chs.api.kafka.uri}")
-    private String resourceChangedUri;
+    private final String chsKafkaApiUrl;
+    private final String resourceChangedUri;
 
     public PscStatementApiService(ResourceChangedRequestMapper mapper, InternalApiClient internalApiClient,
-            Logger logger) {
+            @Value("${chs.api.kafka.url}") String chsKafkaApiUrl,
+            @Value("${chs.api.kafka.uri}") String resourceChangedUri) {
         this.mapper = mapper;
         this.internalApiClient = internalApiClient;
-        this.logger = logger;
+        this.chsKafkaApiUrl = chsKafkaApiUrl;
+        this.resourceChangedUri = resourceChangedUri;
     }
+
 
     public ApiResponse<Void> invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest) {
         internalApiClient.setBasePath(chsKafkaApiUrl);

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiService.java
@@ -1,14 +1,13 @@
 package uk.gov.companieshouse.pscstatementdataapi.api;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.pscstatementdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.api.serialization.LocalDateDeserializer;
 import uk.gov.companieshouse.api.serialization.LocalDateSerializer;
 import uk.gov.companieshouse.pscstatementdataapi.converter.PscStatementReadConverter;
 import uk.gov.companieshouse.pscstatementdataapi.converter.PscStatementWriteConverter;
+import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
 
 import java.time.LocalDate;
@@ -38,6 +39,9 @@ public class ApplicationConfig {
     public InternalApiClient internalApiClient() {
         return ApiSdkManager.getPrivateSDK();
     }
+
+    @Bean
+    public ResourceChangedRequestMapper resourceChangedRequestMapper() { return new ResourceChangedRequestMapper(); }
 
     @Bean
     public CompanyExemptionsApiService companyExemptionsApiService(){

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
@@ -5,6 +5,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.function.Supplier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
@@ -17,11 +21,7 @@ import uk.gov.companieshouse.api.serialization.LocalDateDeserializer;
 import uk.gov.companieshouse.api.serialization.LocalDateSerializer;
 import uk.gov.companieshouse.pscstatementdataapi.converter.PscStatementReadConverter;
 import uk.gov.companieshouse.pscstatementdataapi.converter.PscStatementWriteConverter;
-import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.sdk.manager.ApiSdkManager;
-
-import java.time.LocalDate;
-import java.util.Arrays;
 
 @Configuration
 public class ApplicationConfig {
@@ -41,7 +41,9 @@ public class ApplicationConfig {
     }
 
     @Bean
-    public ResourceChangedRequestMapper resourceChangedRequestMapper() { return new ResourceChangedRequestMapper(); }
+    public Supplier<Instant> instantSupplier() {
+        return Instant::now;
+    }
 
     @Bean
     public CompanyExemptionsApiService companyExemptionsApiService(){

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.pscstatementdataapi.config;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.dockerjava.api.exception.ConflictException;
 import com.mongodb.MongoException;
-
+import java.time.format.DateTimeParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
@@ -13,12 +13,10 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.MethodNotAllowedException;
-import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.api.exception.BadRequestException;
 import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
-
-import java.time.format.DateTimeParseException;
 
 @ControllerAdvice
 public class ExceptionHandlerConfig {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.pscstatementdataapi.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.github.dockerjava.api.exception.ConflictException;
 import com.mongodb.MongoException;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,12 @@ public class ExceptionHandlerConfig {
     public ResponseEntity<Object> handleMethodNotAllowedException(Exception exception) {
         logger.error(exception.getMessage());
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(value = {ConflictException.class})
+    public ResponseEntity<Object> handleConflictException(Exception exception){
+        logger.error(exception.getMessage());
+        return new ResponseEntity<>(exception.getMessage(), HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(value = {Exception.class})

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/LoggingConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/LoggingConfig.java
@@ -1,10 +1,10 @@
 package uk.gov.companieshouse.pscstatementdataapi.config;
 
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Configuration
 public class LoggingConfig {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
@@ -4,7 +4,6 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/MongoPscStatementConfig.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @ConditionalOnProperty(name = "mongodb.transactional", havingValue = "true")
 @Configuration
-@EnableTransactionManagement
 public class MongoPscStatementConfig extends AbstractMongoClientConfiguration {
 
     @Value("${spring.data.mongodb.name}")
@@ -28,11 +27,6 @@ public class MongoPscStatementConfig extends AbstractMongoClientConfiguration {
 
     @Autowired
     MongoCustomConversions mongoCustomConversions;
-
-    @Bean
-    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
-        return new MongoTransactionManager(dbFactory);
-    }
 
     @Override
     protected String getDatabaseName() {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/WebSecurityConfig.java
@@ -2,18 +2,16 @@ package uk.gov.companieshouse.pscstatementdataapi.config;
 
 import java.util.Arrays;
 import java.util.List;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CsrfFilter;
-
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.api.filter.CustomCorsFilter;
 import uk.gov.companieshouse.api.interceptor.InternalUserInterceptor;
 import uk.gov.companieshouse.api.interceptor.UserAuthenticationInterceptor;

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementController.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementController.java
@@ -13,12 +13,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.companieshouse.api.psc.Statement;
-import uk.gov.companieshouse.api.psc.CompanyPscStatement;
-import uk.gov.companieshouse.api.psc.StatementList;
-
-import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.api.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.api.psc.CompanyPscStatement;
+import uk.gov.companieshouse.api.psc.Statement;
+import uk.gov.companieshouse.api.psc.StatementList;
+import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscstatementdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
 

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementController.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementController.java
@@ -88,6 +88,7 @@ public class PscStatementController {
     @DeleteMapping("/{statement_id}/internal")
     public ResponseEntity<Void> deletePscStatement(
             @RequestHeader("x-request-id") String contextId,
+            @RequestHeader("X-DELTA-AT") String deltaAt,
             @PathVariable("company_number") String companyNumber,
             @PathVariable("statement_id") String statementId) {
 
@@ -98,7 +99,7 @@ public class PscStatementController {
         logger.infoContext(contextId, String.format(
                 "Deleting Psc statement information for statement id %s", statementId),
                 DataMapHolder.getLogMap());
-        pscStatementService.deletePscStatement(contextId, companyNumber, statementId);
+        pscStatementService.deletePscStatement(contextId, companyNumber, statementId, deltaAt);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
@@ -1,0 +1,88 @@
+package uk.gov.companieshouse.pscstatementdataapi.model;
+
+import java.util.Objects;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import uk.gov.companieshouse.api.model.Created;
+import uk.gov.companieshouse.api.model.Updated;
+import uk.gov.companieshouse.api.psc.Statement;
+import javax.persistence.Id;
+
+@Document(collection="#{@environment.getProperty('mongodb.pscStatements.collection.name')}")
+public class PscStatementDocument {
+    @Id
+    private String id;
+    private Created created;
+    @Field("company_number")
+    private String companyNumber;
+    private Updated updated;
+    @Field("psc_statement_id")
+    private String pscStatementId;
+    private Statement data;
+    @Field("delta_at")
+    private String deltaAt;
+    public String getId(){
+        return id;
+    }
+    public Created getCreated(){
+        return created;
+    }
+    public String getCompanyNumber() {
+        return companyNumber;
+    }
+    public Updated getUpdated(){
+        return updated;
+    }
+    public String getPscStatementId(){
+        return pscStatementId;
+    }
+    public Statement getData() {
+        return data;
+    }
+    public String getDeltaAt(){
+        return  this.deltaAt;
+    }
+    public void setId(String id){
+        this.id = id;
+    }
+    public void setCreated(Created created){
+        this.created = created;
+    }
+    public void setCompanyNumber(String companyNumber){
+        this.companyNumber = companyNumber;
+    }
+    public void setUpdated(Updated updated){
+        this.updated = updated;
+    }
+    public void setPscStatementId(String pscStatementId){
+        this.pscStatementId = pscStatementId;
+    }
+    public void setData(Statement data) {
+        this.data = data;
+    }
+    public void setDeltaAt(String deltaAt){
+        this.deltaAt = deltaAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PscStatementDocument that = (PscStatementDocument) o;
+        return Objects.equals(getId(), that.getId()) && Objects.equals(getCreated(), that.getCreated())
+                && Objects.equals(getCompanyNumber(), that.getCompanyNumber()) && Objects.equals(
+                getUpdated(), that.getUpdated()) && Objects.equals(getPscStatementId(), that.getPscStatementId())
+                && Objects.equals(getData(), that.getData()) && Objects.equals(getDeltaAt(),
+                that.getDeltaAt());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getCreated(), getCompanyNumber(), getUpdated(), getPscStatementId(), getData(),
+                getDeltaAt());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
@@ -1,12 +1,12 @@
 package uk.gov.companieshouse.pscstatementdataapi.model;
 
 import java.util.Objects;
+import javax.persistence.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 import uk.gov.companieshouse.api.model.Created;
 import uk.gov.companieshouse.api.model.Updated;
 import uk.gov.companieshouse.api.psc.Statement;
-import javax.persistence.Id;
 
 @Document(collection="#{@environment.getProperty('mongodb.pscStatements.collection.name')}")
 public class PscStatementDocument {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/ResourceChangedRequest.java
@@ -1,10 +1,8 @@
-package uk.gov.companieshouse.pscstatementdataapi.util;
+package uk.gov.companieshouse.pscstatementdataapi.model;
 
 import java.util.Objects;
-import java.util.Optional;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
 
-public record ResourceChangedRequest(String contextId, String companyNumber, String statementId, Optional<PscStatementDocument> document, boolean isDelete) {
+public record ResourceChangedRequest(String contextId, String companyNumber, String statementId, PscStatementDocument document, boolean isDelete) {
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/repository/PscStatementRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/repository/PscStatementRepository.java
@@ -5,11 +5,12 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import org.springframework.stereotype.Repository;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
 
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
+
 @Repository
 public interface PscStatementRepository extends MongoRepository<PscStatementDocument, String> {
 

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/repository/PscStatementRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/repository/PscStatementRepository.java
@@ -1,14 +1,12 @@
 package uk.gov.companieshouse.pscstatementdataapi.repository;
 
-import org.springframework.data.mongodb.repository.Aggregation;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
-
-import org.springframework.stereotype.Repository;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 @Repository

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -1,13 +1,20 @@
 package uk.gov.companieshouse.pscstatementdataapi.services;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static uk.gov.companieshouse.pscstatementdataapi.util.DateTimeUtil.isDeltaStale;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.dockerjava.api.exception.ConflictException;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import uk.gov.companieshouse.api.api.CompanyExemptionsApiService;
 import uk.gov.companieshouse.api.api.CompanyMetricsApiService;
 import uk.gov.companieshouse.api.exception.BadRequestException;
 import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
@@ -15,29 +22,19 @@ import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.RegisterApi;
 import uk.gov.companieshouse.api.metrics.RegistersApi;
+import uk.gov.companieshouse.api.model.Created;
 import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.api.psc.Statement;
 import uk.gov.companieshouse.api.psc.StatementLinksType;
 import uk.gov.companieshouse.api.psc.StatementList;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.api.api.CompanyExemptionsApiService;
 import uk.gov.companieshouse.pscstatementdataapi.api.PscStatementApiService;
-import uk.gov.companieshouse.api.model.Created;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.pscstatementdataapi.logging.DataMapHolder;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
-import uk.gov.companieshouse.pscstatementdataapi.repository.PscStatementRepository;
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import uk.gov.companieshouse.pscstatementdataapi.transform.PscStatementTransformer;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
-
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static uk.gov.companieshouse.pscstatementdataapi.util.DateTimeUtil.isDeltaStale;
+import uk.gov.companieshouse.pscstatementdataapi.repository.PscStatementRepository;
+import uk.gov.companieshouse.pscstatementdataapi.transform.PscStatementTransformer;
 
 @Service
 public class PscStatementService {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.exception.ConflictException;
 import java.util.NoSuchElementException;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -110,7 +110,7 @@ public class PscStatementService {
   }
 
   @Transactional
-  public void deletePscStatement(String contextId, String companyNumber, String statementId, String requestDeltaAt) throws ResourceNotFoundException{
+  public void deletePscStatement(String contextId, String companyNumber, String statementId, String requestDeltaAt) {
     if (StringUtils.isBlank(requestDeltaAt)){
       throw new BadRequestException("deltaAt missing from delete request");
     }
@@ -132,7 +132,7 @@ public class PscStatementService {
                       companyNumber, statementId), DataMapHolder.getLogMap());
 
       apiClientService.invokeChsKafkaApi(new ResourceChangedRequest(contextId, companyNumber, statementId, pscStatementDocument, true));
-    } catch (DataAccessException ex) {
+    } catch (ServiceUnavailableException ex) {
       throw new ServiceUnavailableException("Error connecting to MongoDB");
     } catch (IllegalArgumentException ex) {
       throw new BadRequestException("Illegal argument exception caught when processing delete");
@@ -234,17 +234,6 @@ public class PscStatementService {
 
     statementList.setItems(statements);
     return statementList;
-  }
-
-  private boolean hasPscExemptions(String companyNumber) {
-    Optional<CompanyExemptions> companyExemptions = companyExemptionsApiService.getCompanyExemptions(companyNumber);
-
-    return companyExemptions.filter(x ->
-            x.getExemptions() != null &&
-                    (x.getExemptions().getPscExemptAsSharesAdmittedOnMarket()!= null ||
-                            x.getExemptions().getPscExemptAsTradingOnEuRegulatedMarket() != null ||
-                            x.getExemptions().getPscExemptAsTradingOnRegulatedMarket() != null ||
-                            x.getExemptions().getPscExemptAsTradingOnUkRegulatedMarket() != null)).isPresent();
   }
 
   private boolean hasActiveExemptions(String companyNumber) {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -130,7 +130,7 @@ public class PscStatementService {
         apiClientService.invokeChsKafkaApiDelete(new ResourceChangedRequest(contextId, companyNumber, statementId, new PscStatementDocument(), true));
       });
     } catch (DataAccessException ex) {
-      logger.error("Error connecting to MongoDB", ex);
+      logger.error("Error connecting to MongoDB", ex, DataMapHolder.getLogMap());
       throw new ServiceUnavailableException("Error connecting to MongoDB");
     }
   }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformer.java
@@ -1,10 +1,9 @@
 package uk.gov.companieshouse.pscstatementdataapi.transform;
 
-import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.psc.CompanyPscStatement;
-import uk.gov.companieshouse.api.model.Updated;
-
 import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.Updated;
+import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 @Component

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformer.java
@@ -2,10 +2,10 @@ package uk.gov.companieshouse.pscstatementdataapi.transform;
 
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.psc.CompanyPscStatement;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
 import uk.gov.companieshouse.api.model.Updated;
 
 import java.time.LocalDateTime;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 @Component
 public class PscStatementTransformer {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/DateTimeUtil.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/DateTimeUtil.java
@@ -1,16 +1,26 @@
 package uk.gov.companieshouse.pscstatementdataapi.util;
 
+import static java.time.ZoneOffset.UTC;
+
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import org.apache.commons.lang.StringUtils;
 
 public class DateTimeUtil {
 
-    static DateTimeFormatter publishedAtDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final DateTimeFormatter publishedAtDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final DateTimeFormatter deltaAtFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+            .withZone(UTC);
 
     private DateTimeUtil() {}
 
     public static String formatPublishedAt(Instant now) {
-        return publishedAtDateTimeFormatter.format(now.atZone(ZoneOffset.UTC));
+        return publishedAtDateTimeFormatter.format(now.atZone(UTC));
+    }
+
+    public static boolean isDeltaStale(final String requestDeltaAt, final String existingDeltaAt) {
+        return StringUtils.isNotBlank(existingDeltaAt) && OffsetDateTime.parse(requestDeltaAt, deltaAtFormatter)
+                .isBefore(OffsetDateTime.parse(existingDeltaAt, deltaAtFormatter));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequest.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequest.java
@@ -1,0 +1,27 @@
+package uk.gov.companieshouse.pscstatementdataapi.util;
+
+import java.util.Objects;
+import java.util.Optional;
+import uk.gov.companieshouse.api.model.PscStatementDocument;
+
+public record ResourceChangedRequest(String contextId, String companyNumber, String statementId, Optional<PscStatementDocument> document, boolean isDelete) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourceChangedRequest that = (ResourceChangedRequest) o;
+        return isDelete() == that.isDelete() && Objects.equals(contextId, that.contextId)
+                && Objects.equals(statementId, that.statementId) && Objects.equals(companyNumber,
+                that.companyNumber) && Objects.equals(document, that.document);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(contextId, companyNumber, statementId, document, isDelete());
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapper.java
@@ -1,19 +1,27 @@
 package uk.gov.companieshouse.pscstatementdataapi.util;
 
 import java.time.Instant;
-import org.springframework.beans.factory.annotation.Value;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 
+@Component
 public class ResourceChangedRequestMapper {
 
-    private static final String PSC_STATEMENTS_URI = "/company/%s/persons-with-significant-control-statements/%s";
+    private static final String PSC_STATEMENTS_URI = "/company/%s/persons-with-significant-control-statements/%s/internal";
     private static final String CHANGED = "changed";
     private static final String DELETED = "deleted";
+    private static final String RESOURCE_KIND = "persons-with-significant-control-statement";
 
-    @Value("${chs.api.kafka.kind}")
-    private String resourceKind;
+    private final Supplier<Instant> instantSupplier;
+
+
+
+    public ResourceChangedRequestMapper(Supplier<Instant> instantSupplier) {
+        this.instantSupplier = instantSupplier;
+    }
 
     public ChangedResource mapChangedEvent(ResourceChangedRequest request) {
         return buildChangedResource(CHANGED, request);
@@ -27,11 +35,11 @@ public class ResourceChangedRequestMapper {
 
     private ChangedResource buildChangedResource(final String type, ResourceChangedRequest request){
         ChangedResourceEvent event = new ChangedResourceEvent()
-                .publishedAt(DateTimeUtil.formatPublishedAt(Instant.now()))
+                .publishedAt(DateTimeUtil.formatPublishedAt(instantSupplier.get()))
                 .type(type);
         return new ChangedResource()
                 .resourceUri(String.format(PSC_STATEMENTS_URI, request.companyNumber(), request.statementId()))
-                .resourceKind(resourceKind)
+                .resourceKind(RESOURCE_KIND)
                 .event(event)
                 .contextId(request.contextId());
     }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapper.java
@@ -1,0 +1,38 @@
+package uk.gov.companieshouse.pscstatementdataapi.util;
+
+import java.time.Instant;
+import org.springframework.beans.factory.annotation.Value;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
+
+public class ResourceChangedRequestMapper {
+
+    private static final String PSC_STATEMENTS_URI = "/company/%s/persons-with-significant-control-statements/%s";
+    private static final String CHANGED = "changed";
+    private static final String DELETED = "deleted";
+
+    @Value("${chs.api.kafka.kind}")
+    private String resourceKind;
+
+    public ChangedResource mapChangedEvent(ResourceChangedRequest request) {
+        return buildChangedResource(CHANGED, request);
+    }
+
+    public ChangedResource mapDeletedEvent(ResourceChangedRequest request) {
+        ChangedResource changedResource = buildChangedResource(DELETED, request);
+        changedResource.setDeletedData(request.document().getData());
+        return changedResource;
+    }
+
+    private ChangedResource buildChangedResource(final String type, ResourceChangedRequest request){
+        ChangedResourceEvent event = new ChangedResourceEvent()
+                .publishedAt(DateTimeUtil.formatPublishedAt(Instant.now()))
+                .type(type);
+        return new ChangedResource()
+                .resourceUri(String.format(PSC_STATEMENTS_URI, request.companyNumber(), request.statementId()))
+                .resourceKind(resourceKind)
+                .event(event)
+                .contextId(request.contextId());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
@@ -1,5 +1,11 @@
 package uk.gov.companieshouse.pscstatementdataapi.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import org.junit.jupiter.api.Test;
@@ -11,19 +17,13 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PscStatementApiServiceTest {

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.pscstatementdataapi.api;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -17,8 +16,8 @@ import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResource
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
-import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequest;
-import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
+import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
+import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,10 +28,16 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PscStatementApiServiceTest {
 
+    @InjectMocks
+    private PscStatementApiService pscStatementApiService;
+
     @Mock
     private Logger logger;
     @Mock
     InternalApiClient internalApiClient;
+    @Mock
+    ResourceChangedRequestMapper resourceChangedRequestMapper;
+
     @Mock
     PrivateChangedResourceHandler privateChangedResourceHandler;
     @Mock
@@ -41,15 +46,6 @@ class PscStatementApiServiceTest {
     private ApiResponse<Void> response;
     @Mock
     private ResourceChangedRequest resourceChangedRequest;
-
-    private TestHelper testHelper;
-    @InjectMocks
-    private PscStatementApiService pscStatementApiService;
-
-    @BeforeEach
-    void setUp() {
-        testHelper = new TestHelper();
-    }
 
     @Test
     void invokeChsKafkaEndpoint() throws ApiErrorResponseException {
@@ -112,7 +108,7 @@ class PscStatementApiServiceTest {
         when(privateChangedResourcePost.execute()).thenReturn(response);
 
         // When
-        ApiResponse<?> apiResponse = pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
+        ApiResponse<?> apiResponse = pscStatementApiService.invokeChsKafkaApiDelete(resourceChangedRequest);
 
         // Then
         assertThat(apiResponse).isNotNull();
@@ -130,7 +126,7 @@ class PscStatementApiServiceTest {
         when(privateChangedResourcePost.execute()).thenThrow(exception);
 
         // When
-        Executable actual = () -> pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
+        Executable actual = () -> pscStatementApiService.invokeChsKafkaApiDelete(resourceChangedRequest);
 
         // Then
         assertThrows(ServiceUnavailableException.class, actual);
@@ -148,7 +144,7 @@ class PscStatementApiServiceTest {
         when(privateChangedResourcePost.execute()).thenThrow(exception);
 
         // When
-        Executable actual = () -> pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
+        Executable actual = () -> pscStatementApiService.invokeChsKafkaApiDelete(resourceChangedRequest);
 
         // Then
         assertThrows(RuntimeException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.pscstatementdataapi.api;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
-import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/api/PscStatementApiServiceTest.java
@@ -2,9 +2,11 @@ package uk.gov.companieshouse.pscstatementdataapi.api;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+import javax.annotation.Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -16,6 +18,7 @@ import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResource
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +40,8 @@ class PscStatementApiServiceTest {
     private PrivateChangedResourcePost privateChangedResourcePost;
     @Mock
     private ApiResponse<Void> response;
+    @Mock
+    private ResourceChangedRequest resourceChangedRequest;
 
     private TestHelper testHelper;
     @InjectMocks
@@ -49,14 +54,16 @@ class PscStatementApiServiceTest {
 
     @Test
     void invokeChsKafkaEndpoint() throws ApiErrorResponseException {
+        // Given
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenReturn(response);
 
-        ApiResponse<?> apiResponse = pscStatementApiService.invokeChsKafkaApi(
-                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID);
-        assertThat(apiResponse).isNotNull();
+        // When
+        ApiResponse<?> apiResponse = pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
 
+        // Then
+        assertThat(apiResponse).isNotNull();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
         verify(privateChangedResourcePost, times(1)).execute();
@@ -64,14 +71,17 @@ class PscStatementApiServiceTest {
 
     @Test
     void invokeChsKafkaEndpointThrowsApiErrorException() throws ApiErrorResponseException {
+        // Given
         ApiErrorResponseException exception = new ApiErrorResponseException(new HttpResponseException.Builder(408, "Test Request timeout", new HttpHeaders()));
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenThrow(exception);
 
-        assertThrows(ServiceUnavailableException.class, () -> pscStatementApiService.invokeChsKafkaApi(
-                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID));
+        // When
+        Executable actual = () -> pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
 
+        // Then
+        assertThrows(ServiceUnavailableException.class, actual);
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
         verify(privateChangedResourcePost, times(1)).execute();
@@ -79,14 +89,17 @@ class PscStatementApiServiceTest {
 
     @Test
     void invokeChsKafkaEndpointThrowsRuntimeException() throws ApiErrorResponseException {
+        // Given
         RuntimeException exception = new RuntimeException("Test Runtime exception");
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenThrow(exception);
 
-        assertThrows(RuntimeException.class, () -> pscStatementApiService.invokeChsKafkaApi(
-                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID));
+        // When
+        Executable actual = () -> pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
 
+        // Then
+        assertThrows(RuntimeException.class, actual);
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
         verify(privateChangedResourcePost, times(1)).execute();
@@ -94,14 +107,16 @@ class PscStatementApiServiceTest {
 
     @Test
     void invokeChsKafkaEndpointWithDelete() throws ApiErrorResponseException {
+        // Given
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenReturn(response);
 
-        ApiResponse<?> apiResponse = pscStatementApiService.invokeChsKafkaApiWithDeleteEvent(
-                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID, testHelper.getStatement());
-        assertThat(apiResponse).isNotNull();
+        // When
+        ApiResponse<?> apiResponse = pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
 
+        // Then
+        assertThat(apiResponse).isNotNull();
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
         verify(privateChangedResourcePost, times(1)).execute();
@@ -109,14 +124,17 @@ class PscStatementApiServiceTest {
 
     @Test
     void invokeChsKafkaEndpointWithDeleteThrowsApiErrorException() throws ApiErrorResponseException {
+        // Given
         ApiErrorResponseException exception = new ApiErrorResponseException(new HttpResponseException.Builder(408, "Test Request timeout", new HttpHeaders()));
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenThrow(exception);
 
-        assertThrows(ServiceUnavailableException.class, () -> pscStatementApiService.invokeChsKafkaApiWithDeleteEvent(
-                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID, testHelper.getStatement()));
+        // When
+        Executable actual = () -> pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
 
+        // Then
+        assertThrows(ServiceUnavailableException.class, actual);
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
         verify(privateChangedResourcePost, times(1)).execute();
@@ -124,14 +142,17 @@ class PscStatementApiServiceTest {
 
     @Test
     void invokeChsKafkaEndpointWithDeleteThrowsRuntimeException() throws ApiErrorResponseException {
+        // Given
         RuntimeException exception = new RuntimeException("Test Runtime exception");
         when(internalApiClient.privateChangedResourceHandler()).thenReturn(privateChangedResourceHandler);
         when(privateChangedResourceHandler.postChangedResource(Mockito.any(), Mockito.any())).thenReturn(privateChangedResourcePost);
         when(privateChangedResourcePost.execute()).thenThrow(exception);
 
-        assertThrows(RuntimeException.class, () -> pscStatementApiService.invokeChsKafkaApiWithDeleteEvent(
-                TestHelper.X_REQUEST_ID, TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID, testHelper.getStatement()));
+        // When
+        Executable actual = () -> pscStatementApiService.invokeChsKafkaApi(resourceChangedRequest);
 
+        // Then
+        assertThrows(RuntimeException.class, actual);
         verify(internalApiClient, times(1)).privateChangedResourceHandler();
         verify(privateChangedResourceHandler, times(1)).postChangedResource(Mockito.any(), Mockito.any());
         verify(privateChangedResourcePost, times(1)).execute();

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -1,8 +1,12 @@
 package uk.gov.companieshouse.pscstatementdataapi.controller;
 
 import com.github.dockerjava.api.exception.ConflictException;
+import java.time.Instant;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
-public class PscStatementControllerTest {
+class PscStatementControllerTest {
     private static final String GET_URL = String.format("/company/%s/persons-with-significant-control-statements/%s", TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID);
     private static final String PUT_URL = String.format("/company/%s/persons-with-significant-control-statements/%s/internal", TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID);
     private static final String DELETE_URL = String.format("/company/%s/persons-with-significant-control-statements/%s/internal", TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID);

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -37,6 +37,7 @@ public class PscStatementControllerTest {
     private static final String ERIC_IDENTITY_TYPE = "key";
     private static final String ERIC_PRIVILEGES = "*";
     private static final String X_REQUEST_ID = TestHelper.X_REQUEST_ID;
+    private static final String DELTA_AT = TestHelper.DELTA_AT;
 
 
     @MockBean
@@ -138,11 +139,12 @@ public class PscStatementControllerTest {
     void callPscStatementDeleteRequest() throws Exception {
 
         doNothing()
-                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString());
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
 
         mockMvc.perform(delete(DELETE_URL)
                         .contentType(APPLICATION_JSON)
                         .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
                         .header("ERIC-Identity", ERIC_IDENTITY)
                         .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -157,21 +157,6 @@ class PscStatementControllerTest {
     }
 
     @Test
-    void callPscStatementDeleteRequestResourceNotFound() throws Exception {
-        doThrow(ResourceNotFoundException.class)
-                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
-
-        mockMvc.perform(delete(DELETE_URL)
-                        .contentType(APPLICATION_JSON)
-                        .header("x-request-id", X_REQUEST_ID)
-                        .header("X-DELTA-AT", DELTA_AT)
-                        .header("ERIC-Identity", ERIC_IDENTITY)
-                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
-                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
     void callPscStatementDeleteRequestServerError() throws Exception {
         doThrow(ServiceUnavailableException.class)
                 .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
@@ -199,51 +184,6 @@ class PscStatementControllerTest {
                         .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
                 .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    void callPscStatementDeleteRequestMethodNotAllowed() throws Exception {
-        doThrow(MethodNotAllowedException.class)
-                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
-
-        mockMvc.perform(delete(DELETE_URL)
-                        .contentType(APPLICATION_JSON)
-                        .header("x-request-id", X_REQUEST_ID)
-                        .header("X-DELTA-AT", DELTA_AT)
-                        .header("ERIC-Identity", ERIC_IDENTITY)
-                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
-                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
-                .andExpect(status().isMethodNotAllowed());
-    }
-
-    @Test
-    void callPscStatementDeleteRequestConflict() throws Exception {
-        doThrow(ConflictException.class)
-                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
-
-        mockMvc.perform(delete(DELETE_URL)
-                        .contentType(APPLICATION_JSON)
-                        .header("x-request-id", X_REQUEST_ID)
-                        .header("X-DELTA-AT", DELTA_AT)
-                        .header("ERIC-Identity", ERIC_IDENTITY)
-                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
-                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
-                .andExpect(status().isConflict());
-    }
-
-    @Test
-    void callPscStatementDeleteRequestGenericException() throws Exception {
-        doThrow(RuntimeException.class)
-                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
-
-        mockMvc.perform(delete(DELETE_URL)
-                        .contentType(APPLICATION_JSON)
-                        .header("x-request-id", X_REQUEST_ID)
-                        .header("X-DELTA-AT", DELTA_AT)
-                        .header("ERIC-Identity", ERIC_IDENTITY)
-                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
-                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
-                .andExpect(status().isInternalServerError());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
+import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -1,12 +1,20 @@
 package uk.gov.companieshouse.pscstatementdataapi.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.github.dockerjava.api.exception.ConflictException;
-import java.time.Instant;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,20 +30,7 @@ import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
-import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.pscstatementdataapi.controller;
 
+import com.github.dockerjava.api.exception.ConflictException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +10,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.server.MethodNotAllowedException;
 import uk.gov.companieshouse.api.api.CompanyMetricsApiService;
+import uk.gov.companieshouse.api.exception.BadRequestException;
+import uk.gov.companieshouse.api.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
 import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 
@@ -19,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -137,7 +143,6 @@ public class PscStatementControllerTest {
 
     @Test
     void callPscStatementDeleteRequest() throws Exception {
-
         doNothing()
                 .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
 
@@ -149,6 +154,96 @@ public class PscStatementControllerTest {
                         .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
                         .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void callPscStatementDeleteRequestResourceNotFound() throws Exception {
+        doThrow(ResourceNotFoundException.class)
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
+                        .header("ERIC-Identity", ERIC_IDENTITY)
+                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
+                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void callPscStatementDeleteRequestServerError() throws Exception {
+        doThrow(ServiceUnavailableException.class)
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
+                        .header("ERIC-Identity", ERIC_IDENTITY)
+                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
+                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
+                .andExpect(status().isServiceUnavailable());
+    }
+
+    @Test
+    void callPscStatementDeleteRequestBadRequest() throws Exception {
+        doThrow(BadRequestException.class)
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
+                        .header("ERIC-Identity", ERIC_IDENTITY)
+                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
+                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void callPscStatementDeleteRequestMethodNotAllowed() throws Exception {
+        doThrow(MethodNotAllowedException.class)
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
+                        .header("ERIC-Identity", ERIC_IDENTITY)
+                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
+                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @Test
+    void callPscStatementDeleteRequestConflict() throws Exception {
+        doThrow(ConflictException.class)
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
+                        .header("ERIC-Identity", ERIC_IDENTITY)
+                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
+                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void callPscStatementDeleteRequestGenericException() throws Exception {
+        doThrow(RuntimeException.class)
+                .when(pscStatementService).deletePscStatement(anyString(), anyString(), anyString(), anyString());
+
+        mockMvc.perform(delete(DELETE_URL)
+                        .contentType(APPLICATION_JSON)
+                        .header("x-request-id", X_REQUEST_ID)
+                        .header("X-DELTA-AT", DELTA_AT)
+                        .header("ERIC-Identity", ERIC_IDENTITY)
+                        .header("ERIC-Identity-Type", ERIC_IDENTITY_TYPE)
+                        .header("ERIC-Authorised-Key-Roles", ERIC_PRIVILEGES))
+                .andExpect(status().isInternalServerError());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/exception/ResourceNotFoundExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/exception/ResourceNotFoundExceptionTest.java
@@ -1,11 +1,11 @@
 package uk.gov.companieshouse.pscstatementdataapi.exception;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.server.ResponseStatusException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ResourceNotFoundExceptionTest {
 

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
@@ -1,8 +1,30 @@
 package uk.gov.companieshouse.pscstatementdataapi.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import static com.mongodb.internal.connection.tlschannel.util.Util.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.dockerjava.api.exception.ConflictException;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -35,36 +57,12 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.pscstatementdataapi.api.PscStatementApiService;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
+import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.repository.PscStatementRepository;
 import uk.gov.companieshouse.pscstatementdataapi.services.PscStatementService;
 import uk.gov.companieshouse.pscstatementdataapi.transform.PscStatementTransformer;
-import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
 import uk.gov.companieshouse.pscstatementdataapi.util.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static com.mongodb.internal.connection.tlschannel.util.Util.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 @SpringBootTest
 public class PscStatementServiceTest {

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataAccessException;
 import uk.gov.companieshouse.api.api.CompanyExemptionsApiService;
 import uk.gov.companieshouse.api.api.CompanyMetricsApiService;
 import uk.gov.companieshouse.api.exception.BadRequestException;

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
@@ -409,22 +409,6 @@ class PscStatementServiceTest {
         verify(repository).delete(document);
         verifyNoInteractions(apiClientService);
     }
-    @Test
-    void deleteThrowsBadRequestExceptionWhenKafkaThrowsIllegalArgument(){
-        // Given
-        when(repository.getPscStatementByCompanyNumberAndStatementId(anyString(), anyString()))
-                .thenReturn(Optional.of(document));
-        doThrow(ServiceUnavailableException.class).when(apiClientService).invokeChsKafkaApiDelete(any());
-
-        // When
-        Executable actual = () -> pscStatementService.deletePscStatement(CONTEXT_ID, COMPANY_NUMBER, STATEMENT_ID, DELTA_AT);
-
-        // Then
-        assertThrows(ServiceUnavailableException.class, actual);
-        verify(repository).getPscStatementByCompanyNumberAndStatementId(COMPANY_NUMBER, STATEMENT_ID);
-        verify(repository).delete(document);
-        verify(apiClientService).invokeChsKafkaApiDelete(new ResourceChangedRequest(CONTEXT_ID, COMPANY_NUMBER, STATEMENT_ID, document, true));
-    }
 
     @Test
     void processPscStatementSavesStatement() {

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import uk.gov.companieshouse.api.psc.CompanyPscStatement;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 
 import java.time.LocalDateTime;

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformTest.java
@@ -1,18 +1,16 @@
 package uk.gov.companieshouse.pscstatementdataapi.transform;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import uk.gov.companieshouse.api.psc.CompanyPscStatement;
-import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
-import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.psc.CompanyPscStatement;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
+import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 
 public class PscStatementTransformTest {
 

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapperTest.java
@@ -1,0 +1,190 @@
+package uk.gov.companieshouse.pscstatementdataapi.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.api.model.Updated;
+import uk.gov.companieshouse.api.psc.Statement;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
+import uk.gov.companieshouse.pscstatementdataapi.model.ResourceChangedRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceChangedRequestMapperTest {
+
+    private static final String CONTEXT_ID = "654321";
+    private static final String COMPANY_NUMBER = "companyNumber";
+    private static final String STATEMENT_ID = "statementId";
+    private static final String RESOURCE_KIND = "persons-with-significant-control-statement";
+    private static final String RESOURCE_URI = String.format("/company/%s/persons-with-significant-control-statements/%s/internal",
+            COMPANY_NUMBER, STATEMENT_ID);
+    private static final String ETAG = "etag";
+    private static final Instant UPDATED_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    private static final String PUBLISHED_AT = DateTimeUtil.formatPublishedAt(UPDATED_AT);
+
+    @InjectMocks
+    private ResourceChangedRequestMapper mapper;
+
+    @Mock
+    private Supplier<Instant> instantSupplier;
+
+    @Test
+    void shouldMapChangedEvent() {
+        // given
+        ResourceChangedTestArgument argument = ResourceChangedTestArgument.builder()
+                .withRequest(new ResourceChangedRequest(CONTEXT_ID, COMPANY_NUMBER, STATEMENT_ID,
+                        null, false))
+                .withContextId(CONTEXT_ID)
+                .withResourceUri(RESOURCE_URI)
+                .withResourceKind(RESOURCE_KIND)
+                .withEventType("changed")
+                .withEventPublishedAt(PUBLISHED_AT)
+                .build();
+        when(instantSupplier.get()).thenReturn(UPDATED_AT);
+
+        // when
+        ChangedResource actual = mapper.mapChangedEvent(argument.request());
+
+        // then
+        assertEquals(argument.changedResource(), actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("resourceChangedScenarios")
+    void shouldMapDeletedEvent(ResourceChangedTestArgument argument) {
+        // given
+        when(instantSupplier.get()).thenReturn(UPDATED_AT);
+
+        // when
+        ChangedResource actual = mapper.mapDeletedEvent(argument.request());
+
+        // then
+        assertEquals(argument.changedResource(), actual);
+    }
+
+    static Stream<ResourceChangedTestArgument> resourceChangedScenarios() {
+        return Stream.of(
+                ResourceChangedTestArgument.builder()
+                        .withRequest(new ResourceChangedRequest(CONTEXT_ID, COMPANY_NUMBER, STATEMENT_ID,
+                                new PscStatementDocument(), true))
+                        .withContextId(CONTEXT_ID)
+                        .withResourceUri(RESOURCE_URI)
+                        .withResourceKind(RESOURCE_KIND)
+                        .withEventType("deleted")
+                        .withEventPublishedAt(PUBLISHED_AT)
+                        .build(),
+                ResourceChangedTestArgument.builder()
+                        .withRequest(new ResourceChangedRequest(CONTEXT_ID, COMPANY_NUMBER, STATEMENT_ID,
+                                getPscStatementDocument(), true))
+                        .withContextId(CONTEXT_ID)
+                        .withResourceUri(RESOURCE_URI)
+                        .withResourceKind(RESOURCE_KIND)
+                        .withEventType("deleted")
+                        .withDeletedData(getPscStatementData())
+                        .withEventPublishedAt(PUBLISHED_AT)
+                        .build()
+        );
+    }
+
+    record ResourceChangedTestArgument(ResourceChangedRequest request, ChangedResource changedResource) {
+
+        public static ResourceChangedTestArgumentBuilder builder() {
+            return new ResourceChangedTestArgumentBuilder();
+        }
+
+        @Override
+        public String toString() {
+            return this.request.toString();
+        }
+    }
+
+    static class ResourceChangedTestArgumentBuilder {
+        private ResourceChangedRequest request;
+        private String resourceUri;
+        private String resourceKind;
+        private String contextId;
+        private String eventType;
+        private String eventPublishedAt;
+        private Object deletedData;
+
+        public ResourceChangedTestArgumentBuilder withRequest(ResourceChangedRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        public ResourceChangedTestArgumentBuilder withResourceUri(String resourceUri) {
+            this.resourceUri = resourceUri;
+            return this;
+        }
+
+        public ResourceChangedTestArgumentBuilder withResourceKind(String resourceKind) {
+            this.resourceKind = resourceKind;
+            return this;
+        }
+
+        public ResourceChangedTestArgumentBuilder withContextId(String contextId) {
+            this.contextId = contextId;
+            return this;
+        }
+
+        public ResourceChangedTestArgumentBuilder withEventType(String eventType) {
+            this.eventType = eventType;
+            return this;
+        }
+
+        public ResourceChangedTestArgumentBuilder withEventPublishedAt(String eventPublishedAt) {
+            this.eventPublishedAt = eventPublishedAt;
+            return this;
+        }
+
+        public ResourceChangedTestArgumentBuilder withDeletedData(Object deletedData) {
+            this.deletedData = deletedData;
+            return this;
+        }
+
+        public ResourceChangedTestArgument build() {
+            ChangedResource changedResource = new ChangedResource();
+            changedResource.setResourceUri(this.resourceUri);
+            changedResource.setResourceKind(this.resourceKind);
+            changedResource.setContextId(this.contextId);
+            ChangedResourceEvent event = new ChangedResourceEvent();
+            event.setType(this.eventType);
+            event.setPublishedAt(this.eventPublishedAt);
+            changedResource.setEvent(event);
+            changedResource.setDeletedData(deletedData);
+            return new ResourceChangedTestArgument(this.request, changedResource);
+        }
+    }
+
+    private static PscStatementDocument getPscStatementDocument() {
+        PscStatementDocument document = new PscStatementDocument();
+        document.setUpdated(new Updated().setAt(LocalDateTime.ofInstant(UPDATED_AT, ZoneId.of("Z"))));
+        document.setData(getPscStatementData());
+        return document;
+    }
+
+    private static Statement getPscStatementData() {
+        Statement statement = new Statement();
+        statement.setEtag(ETAG);
+        statement.setNotifiedOn(LocalDate.ofInstant(UPDATED_AT, ZoneId.of("Z")));
+        statement.setKind(Statement.KindEnum.PERSONS_WITH_SIGNIFICANT_CONTROL_STATEMENT);
+        statement.setStatement(Statement.StatementEnum.NO_INDIVIDUAL_OR_ENTITY_WITH_SIGNFICANT_CONTROL);
+        return statement;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/util/ResourceChangedRequestMapperTest.java
@@ -106,11 +106,7 @@ class ResourceChangedRequestMapperTest {
         public static ResourceChangedTestArgumentBuilder builder() {
             return new ResourceChangedTestArgumentBuilder();
         }
-
-        @Override
-        public String toString() {
-            return this.request.toString();
-        }
+        
     }
 
     static class ResourceChangedTestArgumentBuilder {

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
@@ -1,5 +1,18 @@
 package uk.gov.companieshouse.pscstatementdataapi.utils;
 
+import static uk.gov.companieshouse.api.exemptions.PscExemptAsSharesAdmittedOnMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_SHARES_ADMITTED_ON_MARKET;
+import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnEuRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_EU_REGULATED_MARKET;
+import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_REGULATED_MARKET;
+import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnUkRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_UK_REGULATED_MARKET;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.springframework.util.FileCopyUtils;
 import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
 import uk.gov.companieshouse.api.exemptions.ExemptionItem;
@@ -13,26 +26,12 @@ import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.metrics.PscApi;
 import uk.gov.companieshouse.api.metrics.RegisterApi;
 import uk.gov.companieshouse.api.metrics.RegistersApi;
+import uk.gov.companieshouse.api.model.Updated;
 import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.api.psc.Statement;
 import uk.gov.companieshouse.api.psc.StatementLinksType;
 import uk.gov.companieshouse.api.psc.StatementList;
-import uk.gov.companieshouse.api.model.Updated;
-
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
-
-import static uk.gov.companieshouse.api.exemptions.PscExemptAsSharesAdmittedOnMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_SHARES_ADMITTED_ON_MARKET;
-import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnEuRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_EU_REGULATED_MARKET;
-import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_REGULATED_MARKET;
-import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnUkRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_UK_REGULATED_MARKET;
 
 public class TestHelper {
 

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
@@ -17,7 +17,6 @@ import uk.gov.companieshouse.api.psc.CompanyPscStatement;
 import uk.gov.companieshouse.api.psc.Statement;
 import uk.gov.companieshouse.api.psc.StatementLinksType;
 import uk.gov.companieshouse.api.psc.StatementList;
-import uk.gov.companieshouse.api.model.PscStatementDocument;
 import uk.gov.companieshouse.api.model.Updated;
 
 import java.io.IOException;
@@ -28,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 import static uk.gov.companieshouse.api.exemptions.PscExemptAsSharesAdmittedOnMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_SHARES_ADMITTED_ON_MARKET;
 import static uk.gov.companieshouse.api.exemptions.PscExemptAsTradingOnEuRegulatedMarketItem.ExemptionTypeEnum.PSC_EXEMPT_AS_TRADING_ON_EU_REGULATED_MARKET;


### PR DESCRIPTION
* Refactor delete service to take deltaAt as parameter
* Update service to check against request and existing deltaAt
* Update service to process delete when resource does not exist
* Refactor kafka api invocation to take ResourceChangedRequest document
* Removed unused method hasPscExemptions from service

Resolves: [DSND-3114](https://companieshouse.atlassian.net/browse/DSND-3114)

[DSND-3114]: https://companieshouse.atlassian.net/browse/DSND-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ