### PR TITLE
DSND-2884: Save raw psc statement id to database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,17 @@
             <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.13</version>
+            <scope>test</scope>
+        </dependency>
         <!--		Transitive deps end here-->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <!-- Internal -->
         <structured-logging.version>3.0.9</structured-logging.version>
-        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.257</private-api-sdk-java.version>
         <data-sync-api-sdk-java.version>1.0.9</data-sync-api-sdk-java.version>
         <api-security-java.version>2.0.5</api-security-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <!-- Internal -->
         <structured-logging.version>3.0.9</structured-logging.version>
-        <private-api-sdk-java.version>4.0.179</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
         <data-sync-api-sdk-java.version>1.0.9</data-sync-api-sdk-java.version>
         <api-security-java.version>2.0.5</api-security-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>

--- a/src/itest/resources/features/psc_statements.feature
+++ b/src/itest/resources/features/psc_statements.feature
@@ -23,20 +23,20 @@ Feature: Process Psc Statement Requests
 
     Examples:
       | companyNumber | statementId                 | data                  |
-      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put |
 
-  Scenario Outline: Processing old psc statement information
+  Scenario Outline: Processing stale psc statement information
 
     Given Psc statements data api service is running
     And a psc statement exists for company number "<companyNumber>" with statement id "<statementId>" and delta_at "<deltaAt>"
-    When I send a PUT request with payload "<oldData>" file for company number "<companyNumber>" with statement id "<statementId>"
+    When I send a PUT request with payload "<staleData>" file for company number "<companyNumber>" with statement id "<statementId>"
     Then I should receive 200 status code
     And the CHS Kafka API is not invoked
     And a statement exists with id "<statementId>" and delta_at "<deltaAt>"
 
     Examples:
-      | companyNumber | statementId                 | deltaAt              | oldData                      |
-      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | 20211008152823383176 | company_psc_statement_old    |
+      | companyNumber | statementId                 | deltaAt              | staleData                         |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | 20211008152823383176 | company_psc_statement_stale_put |
 
 
   Scenario Outline: Processing Psc Statement List GET request successfully
@@ -90,3 +90,27 @@ Feature: Process Psc Statement Requests
     Examples:
       | companyNumber |
       | OC421554      |
+
+  Scenario Outline: Update an existing Psc Statement successfully
+
+    Given Psc statements data api service is running
+    And a psc statement exists for company number "<companyNumber>" with statement id "<statementId>"
+    When I send a PUT request with payload "<data>" file for company number "<companyNumber>" with statement id "<statementId>"
+    Then I should receive 200 status code
+    And the CHS Kafka API is invoked for company number "<companyNumber>" with statement id "<statementId>"
+
+    Examples:
+      | companyNumber | statementId                 | data                      |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put |
+
+  Scenario Outline: Update and existing Psc Statement with legacy psc_statement_id successfully
+
+    Given Psc statements data api service is running
+    And a psc statement exists with legacy data for company number "<companyNumber>" with statement id "<statementId>"
+    When I send a PUT request with payload "<data>" file for company number "<companyNumber>" with statement id "<statementId>"
+    Then I should receive 200 status code
+    And the CHS Kafka API is invoked for company number "<companyNumber>" with statement id "<statementId>"
+
+    Examples:
+      | companyNumber | statementId                 | data                      |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put |

--- a/src/itest/resources/features/psc_statements.feature
+++ b/src/itest/resources/features/psc_statements.feature
@@ -98,10 +98,11 @@ Feature: Process Psc Statement Requests
     When I send a PUT request with payload "<data>" file for company number "<companyNumber>" with statement id "<statementId>"
     Then I should receive 200 status code
     And the CHS Kafka API is invoked for company number "<companyNumber>" with statement id "<statementId>"
+    And the data matches "<result>" for company number "<companyNumber>" and statement id "<statementId>"
 
     Examples:
-      | companyNumber | statementId                 | data                      |
-      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put |
+      | companyNumber | statementId                 | data                      | result                           |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put | company_psc_statement_put_result |
 
   Scenario Outline: Update and existing Psc Statement with legacy psc_statement_id successfully
 
@@ -110,7 +111,8 @@ Feature: Process Psc Statement Requests
     When I send a PUT request with payload "<data>" file for company number "<companyNumber>" with statement id "<statementId>"
     Then I should receive 200 status code
     And the CHS Kafka API is invoked for company number "<companyNumber>" with statement id "<statementId>"
+    And the data matches "<result>" for company number "<companyNumber>" and statement id "<statementId>"
 
     Examples:
-      | companyNumber | statementId                 | data                      |
-      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put |
+      | companyNumber | statementId                 | data                      | result                           |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put | company_psc_statement_put_result |

--- a/src/itest/resources/features/psc_statements_response_codes.feature
+++ b/src/itest/resources/features/psc_statements_response_codes.feature
@@ -29,5 +29,5 @@ Feature: Response codes for psc statements
     And the CHS Kafka API is invoked for company number "<companyNumber>" with statement id "<statementId>"
 
     Examples:
-      | companyNumber | statementId                 | data                  |
-      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement |
+      | companyNumber | statementId                 | data                      |
+      | OC421554      | DHTUrJoAuKdXw7zvkreyAm_SoH0 | company_psc_statement_put |

--- a/src/itest/resources/json/input/company_psc_statement_put.json
+++ b/src/itest/resources/json/input/company_psc_statement_put.json
@@ -1,6 +1,6 @@
 {
-  "psc_statement_id": "DHTUrJoAuKdXw7zvkreyAm_SoH0",
-  "delta_at": "20111008152823383176",
+  "psc_statement_id_raw": "3000000002",
+  "delta_at": "20211008152823383176",
   "company_number": "OC421554",
   "statement": {
     "etag": "1fe0f033e49e55943f70da5a1fb46cc5c9fea46e",

--- a/src/itest/resources/json/input/company_psc_statement_stale_put.json
+++ b/src/itest/resources/json/input/company_psc_statement_stale_put.json
@@ -1,6 +1,6 @@
 {
-  "psc_statement_id": "DHTUrJoAuKdXw7zvkreyAm_SoH0",
-  "delta_at": "20211008152823383176",
+  "psc_statement_id_raw": "DHTUrJoAuKdXw7zvkreyAm_SoH0",
+  "delta_at": "20111008152823383176",
   "company_number": "OC421554",
   "statement": {
     "etag": "1fe0f033e49e55943f70da5a1fb46cc5c9fea46e",

--- a/src/itest/resources/json/input/psc_statement_legacy.json
+++ b/src/itest/resources/json/input/psc_statement_legacy.json
@@ -1,0 +1,21 @@
+{
+  "_id" : "<id>",
+  "created" : {
+    "at" : ISODate("2014-08-29T00:00:00.000Z"),
+  },
+  "company_number" : "<company_number>",
+  "updated" : {
+    "at" : ISODate("2014-08-29T00:00:00.000Z"),
+  },
+  "psc_statement_id_raw" : "3000000002",
+  "data" : {
+    "etag" : "1348e95014c699cebf7494546a5b0d47de8105e5",
+    "kind" : "persons-with-significant-control-statement",
+    "notified_on" : ISODate("2014-08-29T00:00:00.000Z"),
+    "statement" : "all-beneficial-owners-identified",
+    "links" : {
+      "self" : "/company/<company_number>/persons-with-significant-control-statements/<id>"
+    }
+  },
+  "delta_at" : "20200723093435661593"
+}

--- a/src/itest/resources/json/output/company_psc_statement_put_result.json
+++ b/src/itest/resources/json/output/company_psc_statement_put_result.json
@@ -1,18 +1,18 @@
 {
   "_id" : "<id>",
   "created" : {
-    "at" : ISODate("2014-08-29T00:00:00.000Z"),
+    "at" : "2014-08-29T00:00:00.000Z"
   },
   "company_number" : "<company_number>",
   "updated" : {
-    "at" : ISODate("2014-08-29T00:00:00.000Z"),
+    "at" : "2014-08-29T00:00:00.000Z"
   },
-  "psc_statement_id" : "3000000002",
+  "psc_statement_id_raw" : "3000000002",
   "data" : {
-    "etag" : "1348e95014c699cebf7494546a5b0d47de8105e5",
+    "etag" : "1fe0f033e49e55943f70da5a1fb46cc5c9fea46e",
     "kind" : "persons-with-significant-control-statement",
-    "notified_on" : ISODate("2014-08-29T00:00:00.000Z"),
-    "statement" : "all-beneficial-owners-identified",
+    "notified_on" : "2016-07-01T00:00:00.000Z",
+    "statement" : "no-individual-or-entity-with-signficant-control",
     "links" : {
       "self" : "/company/<company_number>/persons-with-significant-control-statements/<id>"
     }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.pscstatementdataapi.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import javax.persistence.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -12,15 +13,19 @@ import uk.gov.companieshouse.api.psc.Statement;
 public class PscStatementDocument {
 
     @Id
+    @JsonProperty("_id")
     private String id;
     private Created created;
     @Field("company_number")
+    @JsonProperty("company_number")
     private String companyNumber;
     private Updated updated;
     @Field("psc_statement_id_raw")
+    @JsonProperty("psc_statement_id_raw")
     private String pscStatementIdRaw;
     private Statement data;
     @Field("delta_at")
+    @JsonProperty("delta_at")
     private String deltaAt;
 
     public String getId() {

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/model/PscStatementDocument.java
@@ -17,8 +17,8 @@ public class PscStatementDocument {
     @Field("company_number")
     private String companyNumber;
     private Updated updated;
-    @Field("psc_statement_id")
-    private String pscStatementId;
+    @Field("psc_statement_id_raw")
+    private String pscStatementIdRaw;
     private Statement data;
     @Field("delta_at")
     private String deltaAt;
@@ -39,8 +39,8 @@ public class PscStatementDocument {
         return updated;
     }
 
-    public String getPscStatementId() {
-        return pscStatementId;
+    public String getPscStatementIdRaw() {
+        return pscStatementIdRaw;
     }
 
     public Statement getData() {
@@ -67,8 +67,8 @@ public class PscStatementDocument {
         this.updated = updated;
     }
 
-    public void setPscStatementId(String pscStatementId) {
-        this.pscStatementId = pscStatementId;
+    public void setPscStatementIdRaw(String pscStatementIdRaw) {
+        this.pscStatementIdRaw = pscStatementIdRaw;
     }
 
     public void setData(Statement data) {
@@ -90,14 +90,14 @@ public class PscStatementDocument {
         PscStatementDocument that = (PscStatementDocument) o;
         return Objects.equals(getId(), that.getId()) && Objects.equals(getCreated(), that.getCreated())
                 && Objects.equals(getCompanyNumber(), that.getCompanyNumber()) && Objects.equals(
-                getUpdated(), that.getUpdated()) && Objects.equals(getPscStatementId(), that.getPscStatementId())
+                getUpdated(), that.getUpdated()) && Objects.equals(getPscStatementIdRaw(), that.getPscStatementIdRaw())
                 && Objects.equals(getData(), that.getData()) && Objects.equals(getDeltaAt(),
                 that.getDeltaAt());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getId(), getCreated(), getCompanyNumber(), getUpdated(), getPscStatementId(), getData(),
+        return Objects.hash(getId(), getCreated(), getCompanyNumber(), getUpdated(), getPscStatementIdRaw(), getData(),
                 getDeltaAt());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformer.java
@@ -17,7 +17,7 @@ public class PscStatementTransformer {
         document.setId(statementId);
         document.setCompanyNumber(companyNumber);
         document.setUpdated(new Updated().setAt(LocalDateTime.now()));
-        document.setPscStatementId(statementId);
+        document.setPscStatementIdRaw(companyPscStatement.getPscStatementIdRaw());
         document.setData(companyPscStatement.getStatement());
         document.setDeltaAt(companyPscStatement.getDeltaAt());
 

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/controller/PscStatementControllerTest.java
@@ -33,13 +33,13 @@ import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 class PscStatementControllerTest {
 
     private static final String GET_URL = String.format("/company/%s/persons-with-significant-control-statements/%s",
-            TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID);
+            TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID_RAW);
     private static final String PUT_URL = String.format(
             "/company/%s/persons-with-significant-control-statements/%s/internal", TestHelper.COMPANY_NUMBER,
-            TestHelper.PSC_STATEMENT_ID);
+            TestHelper.PSC_STATEMENT_ID_RAW);
     private static final String DELETE_URL = String.format(
             "/company/%s/persons-with-significant-control-statements/%s/internal", TestHelper.COMPANY_NUMBER,
-            TestHelper.PSC_STATEMENT_ID);
+            TestHelper.PSC_STATEMENT_ID_RAW);
     private static final String GET_STATEMENT_LIST_URL = String.format(
             "/company/%s/persons-with-significant-control-statements", TestHelper.COMPANY_NUMBER);
     private static final String ERIC_IDENTITY = "Test-Identity";
@@ -71,7 +71,7 @@ class PscStatementControllerTest {
 
     @Test
     void statementResponseReturnedWhenGetRequestInvoked() throws Exception {
-        when(pscStatementService.retrievePscStatementFromDb(TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID))
+        when(pscStatementService.retrievePscStatementFromDb(TestHelper.COMPANY_NUMBER, TestHelper.PSC_STATEMENT_ID_RAW))
                 .thenReturn(testHelper.createStatement());
 
         mockMvc.perform(MockMvcRequestBuilders

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
@@ -66,7 +66,7 @@ import uk.gov.companieshouse.pscstatementdataapi.utils.TestHelper;
 class PscStatementServiceTest {
 
     private static final String CONTEXT_ID = TestHelper.X_REQUEST_ID;
-    private static final String STATEMENT_ID = TestHelper.PSC_STATEMENT_ID;
+    private static final String STATEMENT_ID = TestHelper.PSC_STATEMENT_ID_RAW;
     private static final String COMPANY_NUMBER = TestHelper.COMPANY_NUMBER;
     private static final String DELTA_AT = TestHelper.DELTA_AT;
     private static final String NOT_FOUND_STATEMENT_ID = "not_found_id";

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/transform/PscStatementTransformTest.java
@@ -29,10 +29,10 @@ class PscStatementTransformTest {
         CompanyPscStatement request = testHelper.createCompanyPscStatement();
 
         PscStatementDocument document = transformer.transformPscStatement(TestHelper.COMPANY_NUMBER,
-                TestHelper.PSC_STATEMENT_ID, request);
+                TestHelper.PSC_STATEMENT_ID_RAW, request);
 
         assertEquals(TestHelper.COMPANY_NUMBER, document.getCompanyNumber());
-        assertEquals(TestHelper.PSC_STATEMENT_ID, document.getPscStatementId());
+        assertEquals(TestHelper.PSC_STATEMENT_ID_RAW, document.getPscStatementIdRaw());
         assertEquals(TestHelper.DELTA_AT, document.getDeltaAt());
         assertEquals(testHelper.getStatement(), document.getData());
         assertNotNull(document.getData().getEtag());

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 public class TestHelper {
 
-    public static final String PSC_STATEMENT_ID = "statementId";
+    public static final String PSC_STATEMENT_ID_RAW = "statementId";
     public static final String COMPANY_NUMBER = "companyNumber";
     public static final String DELTA_AT = "20180101093435661593";
     public static final String ETAG = "etag";
@@ -75,7 +75,7 @@ public class TestHelper {
         statement = this.createStatement();
         companyPscStatement.setStatement(statement);
         companyPscStatement.setCompanyNumber(COMPANY_NUMBER);
-        companyPscStatement.setPscStatementId(PSC_STATEMENT_ID);
+        companyPscStatement.setPscStatementIdRaw(PSC_STATEMENT_ID_RAW);
         companyPscStatement.setDeltaAt(DELTA_AT);
         return companyPscStatement;
     }

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/utils/TestHelper.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.pscstatementdataapi.model.PscStatementDocument;
 
 public class TestHelper {
 
-    public static final String PSC_STATEMENT_ID_RAW = "statementId";
+    public static final String PSC_STATEMENT_ID_RAW = "statementIdRaw";
     public static final String COMPANY_NUMBER = "companyNumber";
     public static final String DELTA_AT = "20180101093435661593";
     public static final String ETAG = "etag";

--- a/src/test/resources/psc-statement-example.json
+++ b/src/test/resources/psc-statement-example.json
@@ -1,6 +1,6 @@
 {
   "company_number" : "12388814",
-  "psc_statement_id" : "xyzZGWm42-hTgP-LBAQTjWQnVzM",
+  "psc_statement_id_raw" : "3000000002",
   "statement" : {
     "notified_on" : "2017-01-14",
     "kind" : "persons-with-significant-control-statement",


### PR DESCRIPTION
* Store unencoded psc statement id in document
* Add test cases for updates on existing standard and legacy data
* Update psc statement request jsons

Resolves [DSND-2884](https://companieshouse.atlassian.net/browse/DSND-2884)

[DSND-2884]: https://companieshouse.atlassian.net/browse/DSND-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ