### PR TITLE
DSND-2877: Update spring boot version to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <start-class>uk.gov.companieshouse.pscstatementdataapi.PSCStatementDataApiApplication</start-class>
 
         <maven-build-helper-plugin.version>3.6.0</maven-build-helper-plugin.version>
-        <spring.boot.version>3.4.0</spring.boot.version>
+        <spring.boot.version>3.4.1</spring.boot.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
@@ -54,10 +54,13 @@ class RepositoryITest extends AbstractMongoConfig {
         pscStatementRepository.save(createPscStatementDocument("4"));
         pscStatementRepository.save(createPscStatementDocument("5"));
 
-        assertEquals(5, pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 5).size());
-        assertEquals( 2, pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 2).size());
-        assertEquals( 1, pscStatementRepository.getStatementList(COMPANY_NUMBER, 4, 5).size());
-        assertEquals( 0, pscStatementRepository.getStatementList(
+        assertEquals(5, pscStatementRepository.getStatementList(
+                COMPANY_NUMBER, 0, 5).size());
+        assertEquals(2, pscStatementRepository.getStatementList(
+                COMPANY_NUMBER, 0, 2).size());
+        assertEquals(1, pscStatementRepository.getStatementList(
+                COMPANY_NUMBER, 4, 5).size());
+        assertEquals(0, pscStatementRepository.getStatementList(
                 "Bad Company Number", 0, 5).size());
     }
 

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.pscstatementdataapi.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
@@ -53,10 +54,11 @@ class RepositoryITest extends AbstractMongoConfig {
         pscStatementRepository.save(createPscStatementDocument("4"));
         pscStatementRepository.save(createPscStatementDocument("5"));
 
-        assertThat(pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 5).get()).hasSize(5);
-        assertThat(pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 2).get()).hasSize(2);
-        assertThat(pscStatementRepository.getStatementList(COMPANY_NUMBER, 4, 5).get()).hasSize(1);
-        assertThat(pscStatementRepository.getStatementList("Bad Company Number", 0, 5).get()).isEmpty();
+        assertEquals(pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 5).size(), 5);
+        assertEquals(pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 2).size(), 2);
+        assertEquals(pscStatementRepository.getStatementList(COMPANY_NUMBER, 4, 5).size(), 1);
+        assertEquals(pscStatementRepository.getStatementList(
+                "Bad Company Number", 0, 5).size(), 0);
     }
 
     @Test

--- a/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
+++ b/src/itest/java/uk/gov/companieshouse/pscstatementdataapi/repository/RepositoryITest.java
@@ -54,11 +54,11 @@ class RepositoryITest extends AbstractMongoConfig {
         pscStatementRepository.save(createPscStatementDocument("4"));
         pscStatementRepository.save(createPscStatementDocument("5"));
 
-        assertEquals(pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 5).size(), 5);
-        assertEquals(pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 2).size(), 2);
-        assertEquals(pscStatementRepository.getStatementList(COMPANY_NUMBER, 4, 5).size(), 1);
-        assertEquals(pscStatementRepository.getStatementList(
-                "Bad Company Number", 0, 5).size(), 0);
+        assertEquals(5, pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 5).size());
+        assertEquals( 2, pscStatementRepository.getStatementList(COMPANY_NUMBER, 0, 2).size());
+        assertEquals( 1, pscStatementRepository.getStatementList(COMPANY_NUMBER, 4, 5).size());
+        assertEquals( 0, pscStatementRepository.getStatementList(
+                "Bad Company Number", 0, 5).size());
     }
 
     @Test

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/repository/PscStatementRepository.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/repository/PscStatementRepository.java
@@ -26,7 +26,7 @@ public interface PscStatementRepository extends MongoRepository<PscStatementDocu
             "{'$skip': ?1}",
             "{'$limit': ?2}",
     })
-    Optional<List<PscStatementDocument>> getStatementList(String companyNumber, int startIndex, int itemsPerPage);
+    List<PscStatementDocument> getStatementList(String companyNumber, int startIndex, int itemsPerPage);
 
     @Aggregation(pipeline = {
             "{'$match': { 'company_number' : ?0, $or:[ { 'data.ceased_on': { $gte : { \"$date\" : \"?2\" }} },{ 'data.ceased_on': {$exists: false }} ]} }",
@@ -34,6 +34,6 @@ public interface PscStatementRepository extends MongoRepository<PscStatementDocu
             "{'$skip': ?1}",
             "{'$limit': ?3}",
     })
-    Optional<List<PscStatementDocument>> getStatementListRegisterView(String companyNumber, int startIndex,
+    List<PscStatementDocument> getStatementListRegisterView(String companyNumber, int startIndex,
             OffsetDateTime movedOn, int itemsPerPage);
 }

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/services/PscStatementService.java
@@ -71,14 +71,12 @@ public class PscStatementService {
         if (registerView) {
             return retrievePscStatementListFromDbRegisterView(companyNumber, companyMetrics, startIndex, itemsPerPage);
         }
-
-        Optional<List<PscStatementDocument>> statementListOptional = pscStatementRepository.getStatementList(
+        List<PscStatementDocument> pscStatementDocuments = pscStatementRepository.getStatementList(
                 companyNumber, startIndex, itemsPerPage);
-        List<PscStatementDocument> pscStatementDocuments = statementListOptional.filter(docs -> !docs.isEmpty())
-                .orElseThrow(() ->
-                        new ResourceNotFoundException(HttpStatusCode.valueOf(NOT_FOUND.value()), String.format(
-                                "No PSC statements exists for company: %s", companyNumber)));
-
+        if (pscStatementDocuments.isEmpty()) {
+            throw new ResourceNotFoundException(HttpStatusCode.valueOf(NOT_FOUND.value()), String.format(
+                    "No PSC statements exists for company: %s", companyNumber));
+        }
         return createStatementList(pscStatementDocuments, startIndex, itemsPerPage, companyMetrics, companyNumber,
                 registerView);
     }
@@ -99,14 +97,13 @@ public class PscStatementService {
                         String.format("Company %s is not on the public register", companyNumber)));
 
         if (registerMovedTo.equals("public-register")) {
-            Optional<List<PscStatementDocument>> statementListOptional = pscStatementRepository.getStatementListRegisterView(
+            List<PscStatementDocument> pscStatementDocuments = pscStatementRepository.getStatementListRegisterView(
                     companyNumber, startIndex,
                     metricsData.getRegisters().getPersonsWithSignificantControl().getMovedOn(), itemsPerPage);
-            List<PscStatementDocument> pscStatementDocuments = statementListOptional.filter(docs -> !docs.isEmpty())
-                    .orElseThrow(() ->
-                            new ResourceNotFoundException(HttpStatusCode.valueOf(NOT_FOUND.value()), String.format(
-                                    "No PSC statements exists for company: %s", companyNumber)));
-
+            if (pscStatementDocuments.isEmpty()) {
+                throw new ResourceNotFoundException(HttpStatusCode.valueOf(NOT_FOUND.value()), String.format(
+                        "No PSC statements exists for company: %s", companyNumber));
+            }
             return createStatementList(pscStatementDocuments, startIndex, itemsPerPage, companyMetrics, companyNumber,
                     true);
         } else {

--- a/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/pscstatementdataapi/service/PscStatementServiceTest.java
@@ -129,7 +129,7 @@ class PscStatementServiceTest {
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(testHelper.createMetrics()));
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         StatementList statementList = pscStatementService.retrievePscStatementListFromDb(COMPANY_NUMBER, 0, false, 25);
 
@@ -148,7 +148,7 @@ class PscStatementServiceTest {
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(testHelper.createMetrics()));
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
         when(companyExemptionsApiService.getCompanyExemptions(any())).thenReturn(
                 Optional.ofNullable(testHelper.createExemptions()));
 
@@ -161,8 +161,7 @@ class PscStatementServiceTest {
     @Test
     void whenNoStatementsExistGetStatementListShouldThrow() {
 
-        when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(new ArrayList<>()));
+        when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(new ArrayList<>());
         assertThrows(ResourceNotFoundException.class,
                 () -> pscStatementService.retrievePscStatementListFromDb(COMPANY_NUMBER, 0, false, 25));
     }
@@ -175,7 +174,7 @@ class PscStatementServiceTest {
         document.setData(expectedStatement);
 
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.empty());
 
@@ -196,7 +195,7 @@ class PscStatementServiceTest {
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(testHelper.createMetricsRegisterView("public-register")));
         when(repository.getStatementListRegisterView(anyString(), anyInt(), any(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         StatementList statementList = pscStatementService.retrievePscStatementListFromDb(COMPANY_NUMBER, 0, true, 25);
 
@@ -230,14 +229,14 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         expectedStatement.setCeasedOn(LocalDate.parse("2022-12-20"));
         StatementList expectedStatementList = testHelper.createStatementList();
-        List<Statement> statement = (List<Statement>) expectedStatementList.getItems();
+        List<Statement> statement = expectedStatementList.getItems();
         statement.get(0).setCeasedOn(LocalDate.parse("2022-12-20"));
         document.setData(expectedStatement);
 
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(testHelper.createMetricsRegisterView("public-register")));
         when(repository.getStatementListRegisterView(anyString(), anyInt(), any(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         StatementList statementList = pscStatementService.retrievePscStatementListFromDb(COMPANY_NUMBER, 0, true, 25);
 
@@ -250,8 +249,7 @@ class PscStatementServiceTest {
     @Test
     void whenNoMetricsDataFoundForCompanyInRegisterViewShouldThrow() throws ResourceNotFoundException, IOException {
         // given
-        when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
-                .thenReturn(Optional.empty());
+        when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER)).thenReturn(Optional.empty());
 
         // when
         Exception ex = assertThrows(ResourceNotFoundException.class, () -> {
@@ -299,8 +297,8 @@ class PscStatementServiceTest {
 
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(metricsApi));
-        when(repository.getStatementListRegisterView(anyString(), anyInt(), any(), anyInt())).thenReturn(
-                Optional.of(new ArrayList<>()));
+        when(repository.getStatementListRegisterView(anyString(), anyInt(), any(), anyInt()))
+                .thenReturn(new ArrayList<>());
 
         Exception ex = assertThrows(ResourceNotFoundException.class, () -> {
             pscStatementService.retrievePscStatementListFromDb(COMPANY_NUMBER, 0, true, 25);
@@ -325,7 +323,7 @@ class PscStatementServiceTest {
         metricsApi.setCounts(null);
 
         when(repository.getStatementListRegisterView(anyString(), anyInt(), any(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
         when(companyMetricsApiService.getCompanyMetrics(COMPANY_NUMBER))
                 .thenReturn(Optional.ofNullable(metricsApi));
 
@@ -545,7 +543,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();
@@ -568,7 +566,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();
@@ -590,7 +588,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();
@@ -612,7 +610,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();
@@ -635,7 +633,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();
@@ -655,7 +653,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();
@@ -677,7 +675,7 @@ class PscStatementServiceTest {
         Statement expectedStatement = new Statement();
         document.setData(expectedStatement);
         when(repository.getStatementList(anyString(), anyInt(), anyInt())).thenReturn(
-                Optional.of(Collections.singletonList(document)));
+                Collections.singletonList(document));
 
         CompanyExemptions companyExemptions = new CompanyExemptions();
         Exemptions exemptions = new Exemptions();


### PR DESCRIPTION
* Update method to no longer return optional for lists
* Update tests to fix MappingInstantiationException

**Note: Spring Boot version 3.4.1 will break integration tests for GET lists, if method signature returns a Optional of List.
As a workaround, simply removing the optional and doing an empty check if the service seems to fix the issue.**

Resolves [DSND-2877](https://companieshouse.atlassian.net/browse/DSND-2877)

[DSND-2877]: https://companieshouse.atlassian.net/browse/DSND-2877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ