### PR TITLE
DSND-3096: Remove null fields from stream events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>data-sync-api-sdk-java</artifactId>
             <version>${data-sync-api-sdk-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ApplicationConfig.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -12,6 +14,7 @@ import java.util.function.Supplier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.converter.EnumWriteConverter;
@@ -57,6 +60,17 @@ public class ApplicationConfig {
     @Bean
     public Supplier<InternalApiClient> metricsApiClientSupplier() {
         return () -> buildClient(metricsApiUrl);
+    }
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .setDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     }
 
     @Bean

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/config/ExceptionHandlerConfig.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ConflictException;
 import uk.gov.companieshouse.pscstatementdataapi.exception.ResourceNotFoundException;
+import uk.gov.companieshouse.pscstatementdataapi.exception.SerDesException;
 import uk.gov.companieshouse.pscstatementdataapi.logging.DataMapHolder;
 
 @ControllerAdvice
@@ -57,7 +58,7 @@ public class ExceptionHandlerConfig {
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.CONFLICT);
     }
 
-    @ExceptionHandler(value = {Exception.class})
+    @ExceptionHandler(value = {Exception.class, SerDesException.class})
     public ResponseEntity<String> handleException(Exception exception) {
         LOGGER.error(exception.getMessage(), DataMapHolder.getLogMap());
         return new ResponseEntity<>(exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/uk/gov/companieshouse/pscstatementdataapi/exception/SerDesException.java
+++ b/src/main/java/uk/gov/companieshouse/pscstatementdataapi/exception/SerDesException.java
@@ -1,0 +1,7 @@
+package uk.gov.companieshouse.pscstatementdataapi.exception;
+
+public class SerDesException extends RuntimeException {
+    public SerDesException(String msg, Throwable throwable) {
+        super(msg, throwable);
+    }
+}


### PR DESCRIPTION
* Serialise/deserialise data before passing to changed resource
* Add object mapper config
* Add SerDesException and handling for mapper error cases

Resolves [DSND-3096](https://companieshouse.atlassian.net/browse/DSND-3096)

[DSND-3096]: https://companieshouse.atlassian.net/browse/DSND-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ